### PR TITLE
feat(satellites): add multi-satellite tracking & UI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -363,9 +363,9 @@ MigrationBackup/
 FodyWeavers.xsd
 
 # Custom exclusions
-CLAUDE.md
-/Install.exe
 .claude/
+CLAUDE.md
+AGENTS.md
 CuttingFloor/
 
 # Executable files

--- a/ImagePainter/MultiSatelliteTracker.cs
+++ b/ImagePainter/MultiSatelliteTracker.cs
@@ -1,0 +1,368 @@
+using System.Collections.Concurrent;
+using System.Drawing;
+using WorldMapWallpaper.Properties;
+using WorldMapWallpaper.Shared;
+using WorldMapWallpaper.Shared.Models;
+using WorldMapWallpaper.Shared.Services;
+
+namespace WorldMapWallpaper;
+
+/// <summary>
+/// Tracks multiple satellites and renders them on the world map.
+/// Uses BatchTleService for efficient TLE data fetching and caching.
+/// </summary>
+public class MultiSatelliteTracker
+{
+    private readonly Logger _logger;
+    private readonly double _timeOffset;
+    private readonly double _declination;
+    private readonly BatchTleService _tleService;
+    private readonly SatelliteConfigManager _configManager;
+
+    /// <summary>
+    /// Cache of parsed satellite records from TLE data.
+    /// </summary>
+    private readonly ConcurrentDictionary<int, SatelliteRecord> _satelliteRecords = new();
+
+    /// <summary>
+    /// Cache of custom icons loaded for satellites.
+    /// </summary>
+    private readonly ConcurrentDictionary<int, Bitmap?> _iconCache = new();
+
+    /// <summary>
+    /// Default ISS icon for backwards compatibility.
+    /// </summary>
+    private readonly Bitmap? _defaultIssIcon;
+
+    /// <summary>
+    /// Orbit visualization parameters.
+    /// </summary>
+    private const int OrbitSegments = 50;
+    private const double MinutesBeforeCurrent = 10.0;
+    private const double MinutesAfterCurrent = 10.0;
+
+    /// <summary>
+    /// Initializes a new instance of the MultiSatelliteTracker class.
+    /// </summary>
+    /// <param name="logger">Logger for debug messages.</param>
+    /// <param name="timeOffset">Time offset for sunlight calculation.</param>
+    /// <param name="declination">Solar declination for sunlight calculation.</param>
+    public MultiSatelliteTracker(Logger logger, double timeOffset, double declination)
+    {
+        _logger = logger;
+        _timeOffset = timeOffset;
+        _declination = declination;
+        _tleService = new BatchTleService(msg => logger.Debug(msg));
+        _configManager = SatelliteConfigManager.Instance;
+
+        // Try to load the default ISS icon
+        try
+        {
+            _defaultIssIcon = Resources.ISSIcon;
+        }
+        catch
+        {
+            _logger.Debug("Could not load default ISS icon");
+        }
+    }
+
+    /// <summary>
+    /// Plots all enabled satellites on the map.
+    /// </summary>
+    /// <param name="map">The world map bitmap to draw on.</param>
+    /// <returns>The map with satellites plotted.</returns>
+    public Bitmap PlotSatellites(Bitmap map)
+    {
+        if (!Settings.SatelliteTrackingEnabled)
+        {
+            _logger.Debug("Satellite tracking is disabled");
+            return map;
+        }
+
+        try
+        {
+            var visibleSatellites = _configManager.GetVisibleSatellites().ToList();
+
+            if (visibleSatellites.Count == 0)
+            {
+                _logger.Debug("No visible satellites configured");
+                return map;
+            }
+
+            _logger.Info($"Tracking {visibleSatellites.Count} satellite(s)");
+
+            // Fetch TLE data for all enabled satellites
+            var tleData = _tleService.GetTleForSatellitesAsync(visibleSatellites)
+                .GetAwaiter().GetResult();
+
+            // Parse TLE data into satellite records
+            UpdateSatelliteRecords(tleData);
+
+            // Calculate positions and prepare render data
+            var renderData = new List<SatelliteRenderer.SatelliteRenderData>();
+            var currentTime = DateTime.UtcNow;
+
+            foreach (var config in visibleSatellites)
+            {
+                try
+                {
+                    var position = CalculatePosition(config.NoradId, currentTime);
+                    if (position == null)
+                    {
+                        _logger.Debug($"Could not calculate position for {config.Name}");
+                        continue;
+                    }
+
+                    // Calculate sunlight status
+                    position = CalculateSunlightStatus(position);
+
+                    // Calculate orbit path if enabled
+                    List<SatelliteRenderer.SatellitePosition>? orbitPath = null;
+                    if (config.ShowOrbit)
+                    {
+                        orbitPath = CalculateOrbitPath(config.NoradId, currentTime);
+                    }
+
+                    // Load custom icon if specified
+                    var icon = GetSatelliteIcon(config);
+
+                    renderData.Add(new SatelliteRenderer.SatelliteRenderData
+                    {
+                        Config = config,
+                        Position = position,
+                        OrbitPath = orbitPath,
+                        CustomIcon = icon
+                    });
+
+                    _logger.Debug($"Prepared render data for {config.Name}: " +
+                        $"Lat={position.Latitude:F2}, Lon={position.Longitude:F2}");
+                }
+                catch (Exception ex)
+                {
+                    _logger.Debug($"Error preparing render data for {config.Name}: {ex.Message}");
+                }
+            }
+
+            if (renderData.Count == 0)
+            {
+                _logger.Debug("No satellite positions available to render");
+                return map;
+            }
+
+            // Create a copy of the map and render satellites
+            var mapCopy = new Bitmap(map);
+            using var graphics = Graphics.FromImage(mapCopy);
+
+            var renderer = new SatelliteRenderer(_logger, mapCopy.Width, mapCopy.Height);
+            renderer.RenderSatellites(graphics, renderData.OrderBy(r => r.Config.Priority));
+
+            _logger.Info($"Rendered {renderData.Count} satellite(s) on map");
+            return mapCopy;
+        }
+        catch (Exception ex)
+        {
+            _logger.Debug($"Error plotting satellites: {ex.Message}");
+            return map;
+        }
+    }
+
+    /// <summary>
+    /// Updates the satellite record cache from TLE data.
+    /// </summary>
+    private void UpdateSatelliteRecords(Dictionary<int, TleData> tleData)
+    {
+        foreach (var kvp in tleData)
+        {
+            var record = SatelliteRecord.ParseFromTle(kvp.Value);
+            if (record != null)
+            {
+                _satelliteRecords[kvp.Key] = record;
+                _logger.Debug($"Updated satellite record for {record.SatelliteName} (#{kvp.Key})");
+            }
+        }
+    }
+
+    /// <summary>
+    /// Calculates the current position of a satellite.
+    /// </summary>
+    private SatelliteRenderer.SatellitePosition? CalculatePosition(int noradId, DateTime time)
+    {
+        if (!_satelliteRecords.TryGetValue(noradId, out var record))
+        {
+            _logger.Debug($"No satellite record found for #{noradId}");
+            return null;
+        }
+
+        try
+        {
+            // Use the basic orbital propagator
+            var positionVelocity = BasicOrbitalPropagator.Propagate(record, time);
+            var gmst = OrbitalMath.GreenwichMeanSiderealTime(time);
+            var geodetic = CoordinateTransforms.EciToGeodetic(positionVelocity.Position, gmst);
+
+            var latDegrees = OrbitalMath.RadiansToDegrees(geodetic.Latitude);
+            var lonDegrees = OrbitalMath.RadiansToDegrees(geodetic.Longitude);
+
+            return new SatelliteRenderer.SatellitePosition(
+                latDegrees,
+                lonDegrees,
+                time,
+                false,
+                geodetic.Altitude);
+        }
+        catch (Exception ex)
+        {
+            _logger.Debug($"Error calculating position for #{noradId}: {ex.Message}");
+            return null;
+        }
+    }
+
+    /// <summary>
+    /// Calculates the orbital path for a satellite.
+    /// </summary>
+    private List<SatelliteRenderer.SatellitePosition>? CalculateOrbitPath(int noradId, DateTime currentTime)
+    {
+        if (!_satelliteRecords.TryGetValue(noradId, out var record))
+            return null;
+
+        var orbitPoints = new List<SatelliteRenderer.SatellitePosition>();
+
+        try
+        {
+            for (var i = 0; i < OrbitSegments; i++)
+            {
+                var minutesFromNow = -MinutesBeforeCurrent +
+                    (i * (MinutesBeforeCurrent + MinutesAfterCurrent) / (OrbitSegments - 1));
+                var targetTime = currentTime.AddMinutes(minutesFromNow);
+
+                try
+                {
+                    var positionVelocity = BasicOrbitalPropagator.Propagate(record, targetTime);
+                    var gmst = OrbitalMath.GreenwichMeanSiderealTime(targetTime);
+                    var geodetic = CoordinateTransforms.EciToGeodetic(positionVelocity.Position, gmst);
+
+                    var latitude = OrbitalMath.RadiansToDegrees(geodetic.Latitude);
+                    var longitude = OrbitalMath.RadiansToDegrees(geodetic.Longitude);
+
+                    orbitPoints.Add(new SatelliteRenderer.SatellitePosition(
+                        latitude, longitude, targetTime, false, geodetic.Altitude));
+                }
+                catch
+                {
+                    // Skip this point if calculation fails
+                }
+            }
+        }
+        catch (Exception ex)
+        {
+            _logger.Debug($"Error calculating orbit path for #{noradId}: {ex.Message}");
+        }
+
+        return orbitPoints.Count > 1 ? orbitPoints : null;
+    }
+
+    /// <summary>
+    /// Calculates whether a satellite is in sunlight based on the terminator position.
+    /// </summary>
+    private SatelliteRenderer.SatellitePosition CalculateSunlightStatus(SatelliteRenderer.SatellitePosition position)
+    {
+        try
+        {
+            var terminatorLat = Program.GetTerminatorLatitude(position.Longitude, _timeOffset, _declination);
+
+            var inSunlight = (_declination >= 0 && position.Latitude >= terminatorLat) ||
+                            (_declination < 0 && position.Latitude <= terminatorLat);
+
+            return new SatelliteRenderer.SatellitePosition(
+                position.Latitude,
+                position.Longitude,
+                position.Timestamp,
+                inSunlight,
+                position.AltitudeKm);
+        }
+        catch
+        {
+            return position;
+        }
+    }
+
+    /// <summary>
+    /// Gets the appropriate icon for a satellite.
+    /// </summary>
+    private Bitmap? GetSatelliteIcon(SatelliteConfig config)
+    {
+        // Check cache first
+        if (_iconCache.TryGetValue(config.NoradId, out var cachedIcon))
+            return cachedIcon;
+
+        Bitmap? icon = null;
+
+        // Try to load custom icon if specified
+        if (!string.IsNullOrEmpty(config.IconPath))
+        {
+            icon = SatelliteRenderer.LoadSatelliteIcon(config.IconPath);
+            if (icon != null)
+            {
+                _logger.Debug($"Loaded custom icon for {config.Name}: {config.IconPath}");
+            }
+        }
+
+        // Use default ISS icon for ISS (NORAD ID 25544)
+        if (icon == null && config.NoradId == 25544)
+        {
+            icon = _defaultIssIcon;
+        }
+
+        // Cache the result (even if null - means we'll use the default marker)
+        _iconCache[config.NoradId] = icon;
+
+        return icon;
+    }
+
+    /// <summary>
+    /// Clears the satellite record and icon caches.
+    /// </summary>
+    public void ClearCaches()
+    {
+        _satelliteRecords.Clear();
+
+        // Dispose and clear icon cache (except default ISS icon)
+        foreach (var kvp in _iconCache)
+        {
+            if (kvp.Value != null && kvp.Value != _defaultIssIcon)
+            {
+                kvp.Value.Dispose();
+            }
+        }
+        _iconCache.Clear();
+
+        _logger.Debug("Cleared satellite caches");
+    }
+
+    /// <summary>
+    /// Forces a refresh of TLE data for all enabled satellites.
+    /// </summary>
+    public void RefreshTleData()
+    {
+        try
+        {
+            var satellites = _configManager.Satellites.Where(s => s.Enabled).ToList();
+            if (satellites.Count == 0) return;
+
+            _tleService.RefreshAllTleAsync(satellites).GetAwaiter().GetResult();
+            _logger.Info("Refreshed TLE data for all satellites");
+        }
+        catch (Exception ex)
+        {
+            _logger.Debug($"Error refreshing TLE data: {ex.Message}");
+        }
+    }
+
+    /// <summary>
+    /// Gets cache information for diagnostics.
+    /// </summary>
+    public List<SatelliteCacheInfo> GetTleCacheInfo()
+    {
+        return _tleService.GetCacheInfo();
+    }
+}

--- a/ImagePainter/MultiSatelliteTracker.cs
+++ b/ImagePainter/MultiSatelliteTracker.cs
@@ -37,7 +37,7 @@ public class MultiSatelliteTracker
     /// <summary>
     /// Orbit visualization parameters.
     /// </summary>
-    private const int OrbitSegments = 50;
+    private const int DefaultOrbitSegments = 50;
     private const double MinutesBeforeCurrent = 10.0;
     private const double MinutesAfterCurrent = 10.0;
 
@@ -115,6 +115,13 @@ public class MultiSatelliteTracker
 
                     // Calculate sunlight status
                     position = CalculateSunlightStatus(position);
+
+                    if (_configManager.VisibilityMode == SatelliteVisibilityMode.DaylightOnly &&
+                        !position.IsInSunlight)
+                    {
+                        _logger.Debug($"Skipping {config.Name} because it is not in sunlight");
+                        continue;
+                    }
 
                     // Calculate orbit path if enabled
                     List<SatelliteRenderer.SatellitePosition>? orbitPath = null;
@@ -226,13 +233,17 @@ public class MultiSatelliteTracker
             return null;
 
         var orbitPoints = new List<SatelliteRenderer.SatellitePosition>();
+        var orbitSegments = Math.Clamp(
+            _configManager.Config.DefaultOrbitPoints > 0 ? _configManager.Config.DefaultOrbitPoints : DefaultOrbitSegments,
+            2,
+            200);
 
         try
         {
-            for (var i = 0; i < OrbitSegments; i++)
+            for (var i = 0; i < orbitSegments; i++)
             {
                 var minutesFromNow = -MinutesBeforeCurrent +
-                    (i * (MinutesBeforeCurrent + MinutesAfterCurrent) / (OrbitSegments - 1));
+                    (i * (MinutesBeforeCurrent + MinutesAfterCurrent) / (orbitSegments - 1));
                 var targetTime = currentTime.AddMinutes(minutesFromNow);
 
                 try

--- a/ImagePainter/Program.cs
+++ b/ImagePainter/Program.cs
@@ -347,17 +347,24 @@ namespace WorldMapWallpaper
                     }
                 }
 
-                // Add ISS tracking (if enabled)
+                // Add satellite tracking (if enabled)
                 Bitmap finalImage;
-                if (Settings.ShowISS)
+                if (Settings.SatelliteTrackingEnabled)
                 {
-                    log.Debug("Adding ISS tracking to wallpaper.");
+                    log.Debug("Adding satellite tracking to wallpaper.");
+                    var multiTracker = new MultiSatelliteTracker(log, timeOffset, declination);
+                    finalImage = multiTracker.PlotSatellites(night);
+                }
+                else if (Settings.ShowISS)
+                {
+                    // Fallback to legacy ISS-only tracking if satellite tracking is disabled but ShowISS is on
+                    log.Debug("Using legacy ISS tracking.");
                     var issTracker = new ISSTracker(log, timeOffset, declination);
                     finalImage = issTracker.PlotISS(night);
                 }
                 else
                 {
-                    log.Debug("ISS tracking disabled by user settings.");
+                    log.Debug("Satellite tracking disabled by user settings.");
                     finalImage = night;
                 }
 

--- a/ImagePainter/Properties/AssemblyInfo.cs
+++ b/ImagePainter/Properties/AssemblyInfo.cs
@@ -27,5 +27,5 @@ using System.Runtime.InteropServices;
 //
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
-[assembly: AssemblyVersion("1.5.26.0122")]
-[assembly: AssemblyFileVersion("1.5.26.0122")]
+[assembly: AssemblyVersion("2.0.26.0411")]
+[assembly: AssemblyFileVersion("2.0.26.0411")]

--- a/ImagePainter/SatelliteRenderer.cs
+++ b/ImagePainter/SatelliteRenderer.cs
@@ -1,0 +1,455 @@
+using System.Drawing;
+using System.Drawing.Drawing2D;
+using WorldMapWallpaper.Shared;
+using WorldMapWallpaper.Shared.Models;
+
+namespace WorldMapWallpaper;
+
+/// <summary>
+/// Provides rendering functionality for satellites on the world map.
+/// Supports custom icons, colors, and orbit trail rendering.
+/// </summary>
+public class SatelliteRenderer
+{
+    private readonly Logger _logger;
+    private readonly int _mapWidth;
+    private readonly int _mapHeight;
+
+    /// <summary>
+    /// Default icon size for satellites without custom icons.
+    /// </summary>
+    public const int DefaultIconSize = 16;
+
+    /// <summary>
+    /// Initializes a new instance of the SatelliteRenderer class.
+    /// </summary>
+    /// <param name="logger">Logger for debug messages.</param>
+    /// <param name="mapWidth">Width of the map in pixels.</param>
+    /// <param name="mapHeight">Height of the map in pixels.</param>
+    public SatelliteRenderer(Logger logger, int mapWidth, int mapHeight)
+    {
+        _logger = logger;
+        _mapWidth = mapWidth;
+        _mapHeight = mapHeight;
+    }
+
+    /// <summary>
+    /// Represents a satellite position for rendering.
+    /// </summary>
+    public class SatellitePosition
+    {
+        /// <summary>Gets or sets the latitude in degrees (-90 to 90).</summary>
+        public double Latitude { get; set; }
+
+        /// <summary>Gets or sets the longitude in degrees (-180 to 180).</summary>
+        public double Longitude { get; set; }
+
+        /// <summary>Gets or sets the timestamp of the position.</summary>
+        public DateTime Timestamp { get; set; }
+
+        /// <summary>Gets or sets whether the satellite is in sunlight.</summary>
+        public bool IsInSunlight { get; set; }
+
+        /// <summary>Gets or sets the altitude in kilometers.</summary>
+        public double AltitudeKm { get; set; }
+
+        /// <summary>Creates a new SatellitePosition instance.</summary>
+        public SatellitePosition(double latitude, double longitude, DateTime timestamp, bool inSunlight = false, double altitudeKm = 0)
+        {
+            Latitude = latitude;
+            Longitude = longitude;
+            Timestamp = timestamp;
+            IsInSunlight = inSunlight;
+            AltitudeKm = altitudeKm;
+        }
+    }
+
+    /// <summary>
+    /// Render data for a single satellite including its configuration and current position.
+    /// </summary>
+    public class SatelliteRenderData
+    {
+        /// <summary>Gets or sets the satellite configuration.</summary>
+        public required SatelliteConfig Config { get; set; }
+
+        /// <summary>Gets or sets the current position.</summary>
+        public required SatellitePosition Position { get; set; }
+
+        /// <summary>Gets or sets the orbital path points (optional).</summary>
+        public List<SatellitePosition>? OrbitPath { get; set; }
+
+        /// <summary>Gets or sets the custom icon to use (optional).</summary>
+        public Bitmap? CustomIcon { get; set; }
+    }
+
+    /// <summary>
+    /// Renders a single satellite on the map.
+    /// </summary>
+    /// <param name="graphics">The graphics context to draw on.</param>
+    /// <param name="data">The satellite render data.</param>
+    public void RenderSatellite(Graphics graphics, SatelliteRenderData data)
+    {
+        if (data.Config == null || data.Position == null)
+            return;
+
+        try
+        {
+            var pixelPos = GetPixelCoordinates(data.Position.Latitude, data.Position.Longitude);
+
+            // Draw orbit first (so satellite appears on top)
+            if (data.Config.ShowOrbit && data.OrbitPath != null && data.OrbitPath.Count > 1)
+            {
+                DrawOrbitTrail(graphics, data.OrbitPath, data.Config.Color ?? "#FFFFFF");
+            }
+
+            // Draw satellite icon or marker
+            if (data.CustomIcon != null)
+            {
+                DrawSatelliteIcon(graphics, pixelPos, data.CustomIcon);
+            }
+            else
+            {
+                DrawSatelliteMarker(graphics, pixelPos, data.Config.Color ?? "#FFFFFF");
+            }
+
+            // Draw info label
+            var labelY = pixelPos.Y + (data.CustomIcon?.Height ?? DefaultIconSize) / 2 + 2;
+            DrawSatelliteInfo(graphics, data.Config.Name, data.Position, pixelPos.X, labelY);
+
+            _logger?.Debug($"Rendered satellite {data.Config.Name} at ({pixelPos.X}, {pixelPos.Y})");
+        }
+        catch (Exception ex)
+        {
+            _logger?.Debug($"Error rendering satellite {data.Config.Name}: {ex.Message}");
+        }
+    }
+
+    /// <summary>
+    /// Renders multiple satellites on the map.
+    /// </summary>
+    /// <param name="graphics">The graphics context to draw on.</param>
+    /// <param name="satellites">The satellites to render, sorted by priority.</param>
+    public void RenderSatellites(Graphics graphics, IEnumerable<SatelliteRenderData> satellites)
+    {
+        // First pass: draw all orbits
+        foreach (var sat in satellites)
+        {
+            if (sat.Config.ShowOrbit && sat.OrbitPath != null && sat.OrbitPath.Count > 1)
+            {
+                DrawOrbitTrail(graphics, sat.OrbitPath, sat.Config.Color ?? "#FFFFFF");
+            }
+        }
+
+        // Second pass: draw all satellite icons and labels (so they appear on top)
+        foreach (var sat in satellites)
+        {
+            RenderSatelliteIconAndLabel(graphics, sat);
+        }
+    }
+
+    /// <summary>
+    /// Renders just the icon and label for a satellite (without orbit).
+    /// </summary>
+    private void RenderSatelliteIconAndLabel(Graphics graphics, SatelliteRenderData data)
+    {
+        if (data.Config == null || data.Position == null)
+            return;
+
+        try
+        {
+            var pixelPos = GetPixelCoordinates(data.Position.Latitude, data.Position.Longitude);
+
+            // Draw satellite icon or marker
+            if (data.CustomIcon != null)
+            {
+                DrawSatelliteIcon(graphics, pixelPos, data.CustomIcon);
+            }
+            else
+            {
+                DrawSatelliteMarker(graphics, pixelPos, data.Config.Color ?? "#FFFFFF");
+            }
+
+            // Draw info label
+            var labelY = pixelPos.Y + (data.CustomIcon?.Height ?? DefaultIconSize) / 2 + 2;
+            DrawSatelliteInfo(graphics, data.Config.Name, data.Position, pixelPos.X, labelY);
+        }
+        catch (Exception ex)
+        {
+            _logger?.Debug($"Error rendering satellite icon for {data.Config.Name}: {ex.Message}");
+        }
+    }
+
+    /// <summary>
+    /// Converts latitude and longitude to pixel coordinates on the map.
+    /// Assumes equirectangular projection.
+    /// </summary>
+    /// <param name="latitude">Latitude in degrees (-90 to 90).</param>
+    /// <param name="longitude">Longitude in degrees (-180 to 180).</param>
+    /// <returns>Pixel coordinates on the map.</returns>
+    public Point GetPixelCoordinates(double latitude, double longitude)
+    {
+        var x = (int)((longitude + 180.0) * _mapWidth / 360.0);
+        var y = (int)((90.0 - latitude) * _mapHeight / 180.0);
+
+        // Ensure coordinates are within bounds
+        x = Math.Max(0, Math.Min(_mapWidth - 1, x));
+        y = Math.Max(0, Math.Min(_mapHeight - 1, y));
+
+        return new Point(x, y);
+    }
+
+    /// <summary>
+    /// Draws a satellite icon centered at the specified position.
+    /// </summary>
+    private void DrawSatelliteIcon(Graphics graphics, Point position, Bitmap icon)
+    {
+        var drawX = position.X - (icon.Width / 2);
+        var drawY = position.Y - (icon.Height / 2);
+        graphics.DrawImage(icon, drawX, drawY);
+    }
+
+    /// <summary>
+    /// Draws a default satellite marker (colored circle) at the specified position.
+    /// </summary>
+    private void DrawSatelliteMarker(Graphics graphics, Point position, string hexColor)
+    {
+        var color = ParseHexColor(hexColor);
+
+        using var brush = new SolidBrush(color);
+        using var pen = new Pen(Color.White, 1);
+
+        var rect = new Rectangle(
+            position.X - DefaultIconSize / 2,
+            position.Y - DefaultIconSize / 2,
+            DefaultIconSize,
+            DefaultIconSize);
+
+        // Draw filled circle
+        graphics.FillEllipse(brush, rect);
+        // Draw white border
+        graphics.DrawEllipse(pen, rect);
+
+        // Draw inner highlight
+        using var highlightBrush = new SolidBrush(Color.FromArgb(100, Color.White));
+        var highlightRect = new Rectangle(
+            position.X - DefaultIconSize / 4,
+            position.Y - DefaultIconSize / 4,
+            DefaultIconSize / 2,
+            DefaultIconSize / 2);
+        graphics.FillEllipse(highlightBrush, highlightRect);
+    }
+
+    /// <summary>
+    /// Draws satellite information text below the satellite icon.
+    /// </summary>
+    private void DrawSatelliteInfo(Graphics graphics, string name, SatellitePosition position, int centerX, int startY)
+    {
+        using var font = new Font("Arial", 7f, FontStyle.Regular);
+        using var whiteBrush = new SolidBrush(Color.White);
+        using var shadowBrush = new SolidBrush(Color.FromArgb(128, Color.Black));
+
+        var format = new StringFormat { Alignment = StringAlignment.Center };
+
+        // Format coordinates with proper hemisphere indicators
+        var latDir = position.Latitude >= 0 ? "N" : "S";
+        var lonDir = position.Longitude >= 0 ? "E" : "W";
+        var latValue = Math.Abs(position.Latitude);
+        var lonValue = Math.Abs(position.Longitude);
+
+        // Truncate name if too long
+        var displayName = name.Length > 20 ? name[..17] + "..." : name;
+
+        var lines = new[]
+        {
+            displayName,
+            $"{latValue:F2}{latDir} {lonValue:F2}{lonDir}",
+            $"{position.Timestamp:HH:mm} UTC"
+        };
+
+        var lineHeight = graphics.MeasureString("A", font).Height;
+
+        for (var i = 0; i < lines.Length; i++)
+        {
+            var y = startY + (i * lineHeight);
+
+            // Draw shadow offset by 1 pixel
+            graphics.DrawString(lines[i], font, shadowBrush, centerX + 1, y + 1, format);
+            // Draw main text
+            graphics.DrawString(lines[i], font, whiteBrush, centerX, y, format);
+        }
+    }
+
+    /// <summary>
+    /// Draws the orbital trail for a satellite.
+    /// </summary>
+    private void DrawOrbitTrail(Graphics graphics, List<SatellitePosition> orbitPath, string hexColor)
+    {
+        if (orbitPath == null || orbitPath.Count < 2)
+            return;
+
+        var baseColor = ParseHexColor(hexColor);
+        var orbitColor = Color.FromArgb(80, baseColor);
+
+        using var orbitPen = new Pen(orbitColor, 2);
+        orbitPen.DashStyle = DashStyle.Dot;
+
+        using var arrowPen = new Pen(Color.FromArgb(120, baseColor), 1);
+        using var arrowBrush = new SolidBrush(Color.FromArgb(120, baseColor));
+
+        var points = new List<PointF>();
+        foreach (var pos in orbitPath)
+        {
+            var pixel = GetPixelCoordinates(pos.Latitude, pos.Longitude);
+            points.Add(new PointF(pixel.X, pixel.Y));
+        }
+
+        for (var i = 1; i < points.Count; i++)
+        {
+            var p1 = points[i - 1];
+            var p2 = points[i];
+
+            // Handle map edge wrapping (don't draw lines across the entire map)
+            var deltaX = Math.Abs(p2.X - p1.X);
+            if (deltaX < _mapWidth / 2) // Only draw if points are close
+            {
+                graphics.DrawLine(orbitPen, p1, p2);
+
+                // Draw direction arrows every 10 segments
+                if (i % 10 == 0)
+                {
+                    DrawOrbitDirectionArrow(graphics, arrowPen, arrowBrush, p1, p2);
+                }
+            }
+        }
+    }
+
+    /// <summary>
+    /// Draws a direction arrow on the orbital path.
+    /// </summary>
+    private static void DrawOrbitDirectionArrow(Graphics graphics, Pen pen, Brush brush, PointF p1, PointF p2)
+    {
+        // Calculate direction vector
+        var dx = p2.X - p1.X;
+        var dy = p2.Y - p1.Y;
+        var length = Math.Sqrt(dx * dx + dy * dy);
+
+        if (length < 2) return; // Skip very short segments
+
+        // Normalize direction vector
+        var dirX = dx / length;
+        var dirY = dy / length;
+
+        // Arrow parameters
+        const float arrowSize = 4.0f;
+        const float arrowAngle = 0.5f; // radians (~30 degrees)
+
+        // Calculate arrow position (midpoint of segment)
+        var arrowX = (p1.X + p2.X) / 2;
+        var arrowY = (p1.Y + p2.Y) / 2;
+
+        // Calculate arrow tip
+        var tipX = arrowX + dirX * arrowSize;
+        var tipY = arrowY + dirY * arrowSize;
+
+        // Calculate arrow wings (perpendicular to direction)
+        var perpX = -dirY;
+        var perpY = dirX;
+
+        var wingLength = arrowSize * Math.Sin(arrowAngle);
+        var backLength = arrowSize * Math.Cos(arrowAngle);
+
+        var leftWingX = arrowX - dirX * backLength + perpX * wingLength;
+        var leftWingY = arrowY - dirY * backLength + perpY * wingLength;
+
+        var rightWingX = arrowX - dirX * backLength - perpX * wingLength;
+        var rightWingY = arrowY - dirY * backLength - perpY * wingLength;
+
+        // Draw arrow as small triangle
+        var arrowPoints = new PointF[]
+        {
+            new((float)tipX, (float)tipY),
+            new((float)leftWingX, (float)leftWingY),
+            new((float)rightWingX, (float)rightWingY)
+        };
+
+        graphics.FillPolygon(brush, arrowPoints);
+        graphics.DrawPolygon(pen, arrowPoints);
+    }
+
+    /// <summary>
+    /// Parses a hex color string to a Color value.
+    /// </summary>
+    /// <param name="hexColor">Color in #RRGGBB or #RGB format.</param>
+    /// <returns>The parsed color, or white if parsing fails.</returns>
+    public static Color ParseHexColor(string hexColor)
+    {
+        try
+        {
+            if (string.IsNullOrEmpty(hexColor))
+                return Color.White;
+
+            var hex = hexColor.TrimStart('#');
+
+            // Handle short format #RGB
+            if (hex.Length == 3)
+            {
+                hex = $"{hex[0]}{hex[0]}{hex[1]}{hex[1]}{hex[2]}{hex[2]}";
+            }
+
+            if (hex.Length != 6)
+                return Color.White;
+
+            var r = Convert.ToInt32(hex.Substring(0, 2), 16);
+            var g = Convert.ToInt32(hex.Substring(2, 2), 16);
+            var b = Convert.ToInt32(hex.Substring(4, 2), 16);
+
+            return Color.FromArgb(r, g, b);
+        }
+        catch
+        {
+            return Color.White;
+        }
+    }
+
+    /// <summary>
+    /// Loads a custom satellite icon from a file path.
+    /// </summary>
+    /// <param name="iconPath">Path to the icon file.</param>
+    /// <param name="maxSize">Maximum dimension for the icon (will be scaled if larger).</param>
+    /// <returns>The loaded bitmap, or null if loading fails.</returns>
+    public static Bitmap? LoadSatelliteIcon(string? iconPath, int maxSize = 48)
+    {
+        if (string.IsNullOrEmpty(iconPath) || !File.Exists(iconPath))
+            return null;
+
+        try
+        {
+            var original = new Bitmap(iconPath);
+
+            // Scale if necessary
+            if (original.Width > maxSize || original.Height > maxSize)
+            {
+                var scale = Math.Min((double)maxSize / original.Width, (double)maxSize / original.Height);
+                var newWidth = (int)(original.Width * scale);
+                var newHeight = (int)(original.Height * scale);
+
+                var scaled = new Bitmap(newWidth, newHeight);
+                using (var g = Graphics.FromImage(scaled))
+                {
+                    g.InterpolationMode = InterpolationMode.HighQualityBicubic;
+                    g.SmoothingMode = SmoothingMode.HighQuality;
+                    g.DrawImage(original, 0, 0, newWidth, newHeight);
+                }
+
+                original.Dispose();
+                return scaled;
+            }
+
+            return original;
+        }
+        catch
+        {
+            return null;
+        }
+    }
+}

--- a/Settings/AddSatelliteDialog.cs
+++ b/Settings/AddSatelliteDialog.cs
@@ -1,0 +1,585 @@
+using WorldMapWallpaper.Shared;
+using WorldMapWallpaper.Shared.Models;
+using WorldMapWallpaper.Shared.Services;
+
+namespace WorldMapWallpaper.Settings;
+
+/// <summary>
+/// Dialog for adding a new satellite to track.
+/// Supports both preset selection and custom NORAD ID entry.
+/// </summary>
+public partial class AddSatelliteDialog : Form
+{
+    private readonly ColorScheme _colorScheme;
+    private readonly SatelliteConfigManager _configManager;
+
+    private TabControl _tabControl = null!;
+    private TabPage _presetsTab = null!;
+    private TabPage _customTab = null!;
+
+    // Preset tab controls
+    private ComboBox _categoryCombo = null!;
+    private ListBox _presetListBox = null!;
+    private Label _presetInfoLabel = null!;
+
+    // Custom tab controls
+    private TextBox _noradIdTextBox = null!;
+    private TextBox _nameTextBox = null!;
+    private Label _validationLabel = null!;
+    private Button _validateButton = null!;
+
+    // Common controls
+    private Button _addButton = null!;
+    private Button _cancelButton = null!;
+    private Label _lagrangeWarningLabel = null!;
+
+    /// <summary>
+    /// Gets the satellite that was added, or null if cancelled.
+    /// </summary>
+    public SatelliteConfig? AddedSatellite { get; private set; }
+
+    /// <summary>
+    /// Initializes a new instance of the AddSatelliteDialog class.
+    /// </summary>
+    public AddSatelliteDialog()
+    {
+        _colorScheme = ThemeManager.GetCurrentColorScheme();
+        _configManager = SatelliteConfigManager.Instance;
+
+        InitializeComponent();
+        ApplyTheme();
+        InitializeControls();
+        PopulatePresets();
+    }
+
+    /// <summary>
+    /// Initializes the form component settings.
+    /// </summary>
+    private void InitializeComponent()
+    {
+        this.Text = "Add Satellite";
+        this.Size = new Size(450, 500);
+        this.FormBorderStyle = FormBorderStyle.FixedDialog;
+        this.MaximizeBox = false;
+        this.MinimizeBox = false;
+        this.StartPosition = FormStartPosition.CenterParent;
+        this.Font = new Font("Segoe UI", 9F);
+    }
+
+    /// <summary>
+    /// Applies the current theme colors.
+    /// </summary>
+    private void ApplyTheme()
+    {
+        this.BackColor = _colorScheme.BackgroundColor;
+        this.ForeColor = _colorScheme.PrimaryTextColor;
+    }
+
+    /// <summary>
+    /// Creates and configures all form controls.
+    /// </summary>
+    private void InitializeControls()
+    {
+        var padding = 15;
+        var currentY = padding;
+
+        // Header
+        var headerLabel = new Label
+        {
+            Text = "Add Satellite to Track",
+            Font = new Font("Segoe UI", 14F, FontStyle.Bold),
+            Location = new Point(padding, currentY),
+            Size = new Size(this.ClientSize.Width - 2 * padding, 28),
+            ForeColor = _colorScheme.AccentColor
+        };
+        this.Controls.Add(headerLabel);
+        currentY += 40;
+
+        // Tab Control
+        _tabControl = new TabControl
+        {
+            Location = new Point(padding, currentY),
+            Size = new Size(this.ClientSize.Width - 2 * padding, 320),
+            Font = new Font("Segoe UI", 9F)
+        };
+        this.Controls.Add(_tabControl);
+
+        // Create tabs
+        CreatePresetsTab();
+        CreateCustomTab();
+
+        currentY += 335;
+
+        // Lagrange point warning (hidden by default)
+        _lagrangeWarningLabel = new Label
+        {
+            Text = "",
+            Location = new Point(padding, currentY),
+            Size = new Size(this.ClientSize.Width - 2 * padding, 40),
+            ForeColor = _colorScheme.WarningColor,
+            Font = new Font("Segoe UI", 8F),
+            Visible = false
+        };
+        this.Controls.Add(_lagrangeWarningLabel);
+        currentY += 45;
+
+        // Buttons
+        _addButton = new Button
+        {
+            Text = "Add Satellite",
+            Location = new Point(this.ClientSize.Width - padding - 200, currentY),
+            Size = new Size(95, 30),
+            BackColor = _colorScheme.AccentColor,
+            ForeColor = Color.White,
+            FlatStyle = FlatStyle.Flat,
+            Enabled = false
+        };
+        _addButton.FlatAppearance.BorderSize = 0;
+        _addButton.Click += OnAddClick;
+        this.Controls.Add(_addButton);
+
+        _cancelButton = new Button
+        {
+            Text = "Cancel",
+            Location = new Point(this.ClientSize.Width - padding - 95, currentY),
+            Size = new Size(80, 30),
+            BackColor = _colorScheme.ButtonBackColor,
+            ForeColor = _colorScheme.PrimaryTextColor,
+            FlatStyle = FlatStyle.Flat
+        };
+        _cancelButton.FlatAppearance.BorderSize = 1;
+        _cancelButton.FlatAppearance.BorderColor = _colorScheme.BorderColor;
+        _cancelButton.Click += (s, e) => { this.DialogResult = DialogResult.Cancel; this.Close(); };
+        this.Controls.Add(_cancelButton);
+    }
+
+    /// <summary>
+    /// Creates the presets tab.
+    /// </summary>
+    private void CreatePresetsTab()
+    {
+        _presetsTab = new TabPage
+        {
+            Text = "Preset Satellites",
+            BackColor = _colorScheme.GroupBoxBackColor,
+            Padding = new Padding(10)
+        };
+        _tabControl.TabPages.Add(_presetsTab);
+
+        var categoryLabel = new Label
+        {
+            Text = "Category:",
+            Location = new Point(10, 15),
+            Size = new Size(70, 23),
+            ForeColor = _colorScheme.PrimaryTextColor
+        };
+        _presetsTab.Controls.Add(categoryLabel);
+
+        _categoryCombo = new ComboBox
+        {
+            Location = new Point(85, 12),
+            Size = new Size(300, 23),
+            DropDownStyle = ComboBoxStyle.DropDownList,
+            BackColor = _colorScheme.SurfaceColor,
+            ForeColor = _colorScheme.PrimaryTextColor
+        };
+        _categoryCombo.Items.Add("All Categories");
+        foreach (var category in Enum.GetValues<SatelliteCategory>())
+        {
+            _categoryCombo.Items.Add(category.ToDisplayString());
+        }
+        _categoryCombo.SelectedIndex = 0;
+        _categoryCombo.SelectedIndexChanged += OnCategoryChanged;
+        _presetsTab.Controls.Add(_categoryCombo);
+
+        _presetListBox = new ListBox
+        {
+            Location = new Point(10, 45),
+            Size = new Size(375, 180),
+            BackColor = _colorScheme.SurfaceColor,
+            ForeColor = _colorScheme.PrimaryTextColor,
+            BorderStyle = BorderStyle.FixedSingle
+        };
+        _presetListBox.SelectedIndexChanged += OnPresetSelected;
+        _presetsTab.Controls.Add(_presetListBox);
+
+        _presetInfoLabel = new Label
+        {
+            Text = "Select a satellite to see details",
+            Location = new Point(10, 230),
+            Size = new Size(375, 50),
+            ForeColor = _colorScheme.SecondaryTextColor,
+            Font = new Font("Segoe UI", 8F)
+        };
+        _presetsTab.Controls.Add(_presetInfoLabel);
+    }
+
+    /// <summary>
+    /// Creates the custom satellite tab.
+    /// </summary>
+    private void CreateCustomTab()
+    {
+        _customTab = new TabPage
+        {
+            Text = "Custom Satellite",
+            BackColor = _colorScheme.GroupBoxBackColor,
+            Padding = new Padding(10)
+        };
+        _tabControl.TabPages.Add(_customTab);
+
+        var noradLabel = new Label
+        {
+            Text = "NORAD ID:",
+            Location = new Point(10, 20),
+            Size = new Size(80, 23),
+            ForeColor = _colorScheme.PrimaryTextColor
+        };
+        _customTab.Controls.Add(noradLabel);
+
+        _noradIdTextBox = new TextBox
+        {
+            Location = new Point(95, 17),
+            Size = new Size(150, 23),
+            BackColor = _colorScheme.SurfaceColor,
+            ForeColor = _colorScheme.PrimaryTextColor
+        };
+        _noradIdTextBox.TextChanged += OnNoradIdChanged;
+        _customTab.Controls.Add(_noradIdTextBox);
+
+        _validateButton = new Button
+        {
+            Text = "Validate",
+            Location = new Point(255, 16),
+            Size = new Size(80, 25),
+            BackColor = _colorScheme.ButtonBackColor,
+            ForeColor = _colorScheme.PrimaryTextColor,
+            FlatStyle = FlatStyle.Flat
+        };
+        _validateButton.FlatAppearance.BorderSize = 1;
+        _validateButton.FlatAppearance.BorderColor = _colorScheme.BorderColor;
+        _validateButton.Click += OnValidateClick;
+        _customTab.Controls.Add(_validateButton);
+
+        var nameLabel = new Label
+        {
+            Text = "Name:",
+            Location = new Point(10, 55),
+            Size = new Size(80, 23),
+            ForeColor = _colorScheme.PrimaryTextColor
+        };
+        _customTab.Controls.Add(nameLabel);
+
+        _nameTextBox = new TextBox
+        {
+            Location = new Point(95, 52),
+            Size = new Size(290, 23),
+            BackColor = _colorScheme.SurfaceColor,
+            ForeColor = _colorScheme.PrimaryTextColor
+        };
+        _nameTextBox.TextChanged += OnNameChanged;
+        _customTab.Controls.Add(_nameTextBox);
+
+        _validationLabel = new Label
+        {
+            Text = "Enter a NORAD catalog number and click Validate",
+            Location = new Point(10, 90),
+            Size = new Size(375, 80),
+            ForeColor = _colorScheme.SecondaryTextColor,
+            Font = new Font("Segoe UI", 8F)
+        };
+        _customTab.Controls.Add(_validationLabel);
+
+        var helpLabel = new Label
+        {
+            Text = "Tip: Find NORAD IDs at celestrak.org or n2yo.com",
+            Location = new Point(10, 180),
+            Size = new Size(375, 20),
+            ForeColor = _colorScheme.SecondaryTextColor,
+            Font = new Font("Segoe UI", 8F, FontStyle.Italic)
+        };
+        _customTab.Controls.Add(helpLabel);
+    }
+
+    /// <summary>
+    /// Populates the preset list based on selected category.
+    /// </summary>
+    private void PopulatePresets()
+    {
+        _presetListBox.Items.Clear();
+
+        IEnumerable<SatellitePreset> presets = _categoryCombo.SelectedIndex == 0
+            ? SatellitePreset.All
+            : SatellitePreset.ByCategory((SatelliteCategory)(_categoryCombo.SelectedIndex - 1));
+
+        foreach (var preset in presets)
+        {
+            // Skip if already configured
+            if (_configManager.ContainsSatellite(preset.NoradId))
+                continue;
+
+            _presetListBox.Items.Add(new PresetItem(preset));
+        }
+
+        _addButton.Enabled = false;
+        _presetInfoLabel.Text = "Select a satellite to see details";
+        _lagrangeWarningLabel.Visible = false;
+    }
+
+    /// <summary>
+    /// Handler for category selection change.
+    /// </summary>
+    private void OnCategoryChanged(object? sender, EventArgs e)
+    {
+        PopulatePresets();
+    }
+
+    /// <summary>
+    /// Handler for preset selection change.
+    /// </summary>
+    private void OnPresetSelected(object? sender, EventArgs e)
+    {
+        if (_presetListBox.SelectedItem is PresetItem item)
+        {
+            var preset = item.Preset;
+            _presetInfoLabel.Text = $"NORAD ID: {preset.NoradId}\n" +
+                                    $"Category: {preset.Category.ToDisplayString()}\n" +
+                                    $"Orbit: {preset.OrbitType}";
+
+            // Check for Lagrange point
+            if (preset.IsLagrangePoint)
+            {
+                _lagrangeWarningLabel.Text = $"Warning: {preset.Name} is at Lagrange Point {preset.LagrangePointLocation}.\n" +
+                                             "Position shown on the map will not be accurate.";
+                _lagrangeWarningLabel.Visible = true;
+            }
+            else
+            {
+                _lagrangeWarningLabel.Visible = false;
+            }
+
+            _addButton.Enabled = true;
+        }
+        else
+        {
+            _addButton.Enabled = false;
+            _lagrangeWarningLabel.Visible = false;
+        }
+    }
+
+    /// <summary>
+    /// Handler for NORAD ID text change.
+    /// </summary>
+    private void OnNoradIdChanged(object? sender, EventArgs e)
+    {
+        _addButton.Enabled = false;
+        _validationLabel.Text = "Enter a NORAD catalog number and click Validate";
+        _validationLabel.ForeColor = _colorScheme.SecondaryTextColor;
+        _lagrangeWarningLabel.Visible = false;
+    }
+
+    /// <summary>
+    /// Handler for name text change.
+    /// </summary>
+    private void OnNameChanged(object? sender, EventArgs e)
+    {
+        // Re-enable add button if validation passed and name is provided
+        if (_validationLabel.ForeColor == _colorScheme.SuccessColor &&
+            !string.IsNullOrWhiteSpace(_nameTextBox.Text))
+        {
+            _addButton.Enabled = true;
+        }
+    }
+
+    /// <summary>
+    /// Handler for validate button click.
+    /// </summary>
+    private async void OnValidateClick(object? sender, EventArgs e)
+    {
+        if (!int.TryParse(_noradIdTextBox.Text, out var noradId) || noradId <= 0)
+        {
+            _validationLabel.Text = "Please enter a valid NORAD catalog number (positive integer)";
+            _validationLabel.ForeColor = _colorScheme.ErrorColor;
+            return;
+        }
+
+        // Check if already configured
+        if (_configManager.ContainsSatellite(noradId))
+        {
+            _validationLabel.Text = "This satellite is already in your configuration";
+            _validationLabel.ForeColor = _colorScheme.ErrorColor;
+            return;
+        }
+
+        // Check for Lagrange point
+        var lagrangeResult = LagrangePointDetector.DetectLagrangePoint(noradId);
+        if (lagrangeResult.IsLagrangePoint)
+        {
+            _lagrangeWarningLabel.Text = LagrangePointDetector.GetWarningMessage(lagrangeResult);
+            _lagrangeWarningLabel.Visible = true;
+
+            if (!string.IsNullOrEmpty(lagrangeResult.SatelliteName))
+            {
+                _nameTextBox.Text = lagrangeResult.SatelliteName;
+            }
+        }
+        else
+        {
+            _lagrangeWarningLabel.Visible = false;
+        }
+
+        _validateButton.Enabled = false;
+        _validationLabel.Text = "Validating...";
+        _validationLabel.ForeColor = _colorScheme.SecondaryTextColor;
+
+        try
+        {
+            // Try to fetch TLE data to validate the satellite exists
+            var tleService = new BatchTleService();
+            var tle = await tleService.FetchSingleTleAsync(noradId);
+
+            if (tle != null)
+            {
+                _validationLabel.Text = $"Satellite found: {tle.SatelliteName}\n" +
+                                        $"NORAD ID: {tle.CatalogNumber}\n" +
+                                        $"TLE Epoch: {tle.EpochDate:yyyy-MM-dd HH:mm} UTC";
+                _validationLabel.ForeColor = _colorScheme.SuccessColor;
+
+                if (string.IsNullOrWhiteSpace(_nameTextBox.Text))
+                {
+                    _nameTextBox.Text = tle.SatelliteName;
+                }
+
+                // Check for Lagrange point based on TLE mean motion
+                if (!lagrangeResult.IsLagrangePoint)
+                {
+                    // Extract mean motion from TLE and check
+                    var meanMotion = ExtractMeanMotionFromTle(tle);
+                    if (meanMotion.HasValue)
+                    {
+                        var tleBasedResult = LagrangePointDetector.DetectLagrangePoint(noradId, meanMotion);
+                        if (tleBasedResult.IsLagrangePoint)
+                        {
+                            _lagrangeWarningLabel.Text = LagrangePointDetector.GetWarningMessage(tleBasedResult);
+                            _lagrangeWarningLabel.Visible = true;
+                        }
+                    }
+                }
+
+                _addButton.Enabled = !string.IsNullOrWhiteSpace(_nameTextBox.Text);
+            }
+            else
+            {
+                _validationLabel.Text = "Satellite not found. Please check the NORAD ID.";
+                _validationLabel.ForeColor = _colorScheme.ErrorColor;
+            }
+        }
+        catch (Exception ex)
+        {
+            _validationLabel.Text = $"Validation failed: {ex.Message}";
+            _validationLabel.ForeColor = _colorScheme.ErrorColor;
+        }
+        finally
+        {
+            _validateButton.Enabled = true;
+        }
+    }
+
+    /// <summary>
+    /// Extracts mean motion from TLE data.
+    /// </summary>
+    private static double? ExtractMeanMotionFromTle(TleData tle)
+    {
+        try
+        {
+            if (tle.Line2.Length >= 63)
+            {
+                var meanMotionStr = tle.Line2.Substring(52, 11);
+                if (double.TryParse(meanMotionStr, out var meanMotion))
+                {
+                    return meanMotion;
+                }
+            }
+        }
+        catch
+        {
+            // Ignore parsing errors
+        }
+        return null;
+    }
+
+    /// <summary>
+    /// Handler for add button click.
+    /// </summary>
+    private void OnAddClick(object? sender, EventArgs e)
+    {
+        if (_tabControl.SelectedTab == _presetsTab)
+        {
+            // Add from preset
+            if (_presetListBox.SelectedItem is PresetItem item)
+            {
+                if (_configManager.AddFromPreset(item.Preset))
+                {
+                    AddedSatellite = _configManager.GetSatellite(item.Preset.NoradId);
+                    this.DialogResult = DialogResult.OK;
+                    this.Close();
+                }
+                else
+                {
+                    MessageBox.Show("Failed to add satellite. It may already exist.",
+                        "Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
+                }
+            }
+        }
+        else
+        {
+            // Add custom satellite
+            if (int.TryParse(_noradIdTextBox.Text, out var noradId) &&
+                !string.IsNullOrWhiteSpace(_nameTextBox.Text))
+            {
+                var config = new SatelliteConfig
+                {
+                    Name = _nameTextBox.Text.Trim(),
+                    NoradId = noradId,
+                    Enabled = true,
+                    ShowOrbit = true,
+                    Category = SatelliteCategory.Default
+                };
+
+                // Check for Lagrange point
+                var lagrangeResult = LagrangePointDetector.DetectLagrangePoint(noradId);
+                config.IsLagrangePoint = lagrangeResult.IsLagrangePoint;
+
+                if (_configManager.AddSatellite(config))
+                {
+                    AddedSatellite = config;
+                    this.DialogResult = DialogResult.OK;
+                    this.Close();
+                }
+                else
+                {
+                    MessageBox.Show("Failed to add satellite. It may already exist.",
+                        "Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
+                }
+            }
+        }
+    }
+
+    /// <summary>
+    /// Helper class for preset list items.
+    /// </summary>
+    private class PresetItem
+    {
+        public SatellitePreset Preset { get; }
+
+        public PresetItem(SatellitePreset preset)
+        {
+            Preset = preset;
+        }
+
+        public override string ToString()
+        {
+            var suffix = Preset.IsLagrangePoint ? $" ({Preset.LagrangePointLocation})" : $" ({Preset.OrbitType})";
+            return Preset.Name + suffix;
+        }
+    }
+}

--- a/Settings/AddSatelliteDialog.cs
+++ b/Settings/AddSatelliteDialog.cs
@@ -1,3 +1,4 @@
+using System.Globalization;
 using WorldMapWallpaper.Shared;
 using WorldMapWallpaper.Shared.Models;
 using WorldMapWallpaper.Shared.Services;
@@ -494,7 +495,7 @@ public partial class AddSatelliteDialog : Form
             if (tle.Line2.Length >= 63)
             {
                 var meanMotionStr = tle.Line2.Substring(52, 11);
-                if (double.TryParse(meanMotionStr, out var meanMotion))
+                if (double.TryParse(meanMotionStr, NumberStyles.Float, CultureInfo.InvariantCulture, out var meanMotion))
                 {
                     return meanMotion;
                 }

--- a/Settings/SatelliteEditDialog.cs
+++ b/Settings/SatelliteEditDialog.cs
@@ -1,0 +1,424 @@
+using System.Drawing;
+using WorldMapWallpaper.Shared;
+using WorldMapWallpaper.Shared.Models;
+using WorldMapWallpaper.Shared.Services;
+
+namespace WorldMapWallpaper.Settings;
+
+/// <summary>
+/// Dialog for editing satellite configuration.
+/// Allows changing name, color, icon, and visibility settings.
+/// </summary>
+public partial class SatelliteEditDialog : Form
+{
+    private readonly ColorScheme _colorScheme;
+    private readonly SatelliteConfig _satellite;
+
+    private TextBox _nameTextBox = null!;
+    private CheckBox _enabledCheckBox = null!;
+    private CheckBox _showOrbitCheckBox = null!;
+    private Panel _colorPreviewPanel = null!;
+    private Button _colorButton = null!;
+    private TextBox _iconPathTextBox = null!;
+    private Button _browseIconButton = null!;
+    private Button _clearIconButton = null!;
+    private Label _infoLabel = null!;
+    private Button _saveButton = null!;
+    private Button _cancelButton = null!;
+
+    private string _selectedColor;
+
+    /// <summary>
+    /// Gets whether the satellite was modified.
+    /// </summary>
+    public bool WasModified { get; private set; }
+
+    /// <summary>
+    /// Initializes a new instance of the SatelliteEditDialog class.
+    /// </summary>
+    /// <param name="satellite">The satellite configuration to edit.</param>
+    public SatelliteEditDialog(SatelliteConfig satellite)
+    {
+        _satellite = satellite ?? throw new ArgumentNullException(nameof(satellite));
+        _selectedColor = satellite.Color ?? "#FFFFFF";
+        _colorScheme = ThemeManager.GetCurrentColorScheme();
+
+        InitializeComponent();
+        ApplyTheme();
+        InitializeControls();
+        LoadSatelliteData();
+    }
+
+    /// <summary>
+    /// Initializes the form component settings.
+    /// </summary>
+    private void InitializeComponent()
+    {
+        this.Text = "Edit Satellite";
+        this.Size = new Size(420, 400);
+        this.FormBorderStyle = FormBorderStyle.FixedDialog;
+        this.MaximizeBox = false;
+        this.MinimizeBox = false;
+        this.StartPosition = FormStartPosition.CenterParent;
+        this.Font = new Font("Segoe UI", 9F);
+    }
+
+    /// <summary>
+    /// Applies the current theme colors.
+    /// </summary>
+    private void ApplyTheme()
+    {
+        this.BackColor = _colorScheme.BackgroundColor;
+        this.ForeColor = _colorScheme.PrimaryTextColor;
+    }
+
+    /// <summary>
+    /// Creates and configures all form controls.
+    /// </summary>
+    private void InitializeControls()
+    {
+        var padding = 15;
+        var currentY = padding;
+        var labelWidth = 100;
+        var controlLeft = padding + labelWidth + 5;
+        var controlWidth = this.ClientSize.Width - controlLeft - padding;
+
+        // Header
+        var headerLabel = new Label
+        {
+            Text = "Edit Satellite Settings",
+            Font = new Font("Segoe UI", 14F, FontStyle.Bold),
+            Location = new Point(padding, currentY),
+            Size = new Size(this.ClientSize.Width - 2 * padding, 28),
+            ForeColor = _colorScheme.AccentColor
+        };
+        this.Controls.Add(headerLabel);
+        currentY += 40;
+
+        // Satellite info (read-only)
+        _infoLabel = new Label
+        {
+            Location = new Point(padding, currentY),
+            Size = new Size(this.ClientSize.Width - 2 * padding, 35),
+            ForeColor = _colorScheme.SecondaryTextColor,
+            Font = new Font("Segoe UI", 8F)
+        };
+        this.Controls.Add(_infoLabel);
+        currentY += 45;
+
+        // Name
+        var nameLabel = new Label
+        {
+            Text = "Display Name:",
+            Location = new Point(padding, currentY + 3),
+            Size = new Size(labelWidth, 23),
+            ForeColor = _colorScheme.PrimaryTextColor
+        };
+        this.Controls.Add(nameLabel);
+
+        _nameTextBox = new TextBox
+        {
+            Location = new Point(controlLeft, currentY),
+            Size = new Size(controlWidth, 23),
+            BackColor = _colorScheme.SurfaceColor,
+            ForeColor = _colorScheme.PrimaryTextColor
+        };
+        this.Controls.Add(_nameTextBox);
+        currentY += 35;
+
+        // Enabled checkbox
+        _enabledCheckBox = new CheckBox
+        {
+            Text = "Enable tracking for this satellite",
+            Location = new Point(padding, currentY),
+            Size = new Size(this.ClientSize.Width - 2 * padding, 23),
+            ForeColor = _colorScheme.PrimaryTextColor
+        };
+        this.Controls.Add(_enabledCheckBox);
+        currentY += 30;
+
+        // Show orbit checkbox
+        _showOrbitCheckBox = new CheckBox
+        {
+            Text = "Show orbital path on map",
+            Location = new Point(padding, currentY),
+            Size = new Size(this.ClientSize.Width - 2 * padding, 23),
+            ForeColor = _colorScheme.PrimaryTextColor
+        };
+        this.Controls.Add(_showOrbitCheckBox);
+        currentY += 40;
+
+        // Color selection
+        var colorLabel = new Label
+        {
+            Text = "Trail Color:",
+            Location = new Point(padding, currentY + 3),
+            Size = new Size(labelWidth, 23),
+            ForeColor = _colorScheme.PrimaryTextColor
+        };
+        this.Controls.Add(colorLabel);
+
+        _colorPreviewPanel = new Panel
+        {
+            Location = new Point(controlLeft, currentY),
+            Size = new Size(30, 25),
+            BorderStyle = BorderStyle.FixedSingle
+        };
+        this.Controls.Add(_colorPreviewPanel);
+
+        _colorButton = new Button
+        {
+            Text = "Change...",
+            Location = new Point(controlLeft + 40, currentY),
+            Size = new Size(80, 25),
+            BackColor = _colorScheme.ButtonBackColor,
+            ForeColor = _colorScheme.PrimaryTextColor,
+            FlatStyle = FlatStyle.Flat
+        };
+        _colorButton.FlatAppearance.BorderSize = 1;
+        _colorButton.FlatAppearance.BorderColor = _colorScheme.BorderColor;
+        _colorButton.Click += OnColorButtonClick;
+        this.Controls.Add(_colorButton);
+
+        // Quick color buttons
+        var quickColorX = controlLeft + 130;
+        foreach (var hexColor in SatellitePreset.DefaultColorPalette.Take(6))
+        {
+            var quickColorBtn = new Panel
+            {
+                Location = new Point(quickColorX, currentY + 2),
+                Size = new Size(20, 20),
+                BackColor = ParseHexColor(hexColor),
+                BorderStyle = BorderStyle.FixedSingle,
+                Cursor = Cursors.Hand
+            };
+            var colorValue = hexColor; // Capture for closure
+            quickColorBtn.Click += (s, e) => SelectColor(colorValue);
+            this.Controls.Add(quickColorBtn);
+            quickColorX += 25;
+        }
+
+        currentY += 40;
+
+        // Icon path
+        var iconLabel = new Label
+        {
+            Text = "Custom Icon:",
+            Location = new Point(padding, currentY + 3),
+            Size = new Size(labelWidth, 23),
+            ForeColor = _colorScheme.PrimaryTextColor
+        };
+        this.Controls.Add(iconLabel);
+
+        _iconPathTextBox = new TextBox
+        {
+            Location = new Point(controlLeft, currentY),
+            Size = new Size(controlWidth - 130, 23),
+            BackColor = _colorScheme.SurfaceColor,
+            ForeColor = _colorScheme.PrimaryTextColor,
+            ReadOnly = true
+        };
+        this.Controls.Add(_iconPathTextBox);
+
+        _browseIconButton = new Button
+        {
+            Text = "Browse",
+            Location = new Point(this.ClientSize.Width - padding - 120, currentY),
+            Size = new Size(60, 25),
+            BackColor = _colorScheme.ButtonBackColor,
+            ForeColor = _colorScheme.PrimaryTextColor,
+            FlatStyle = FlatStyle.Flat
+        };
+        _browseIconButton.FlatAppearance.BorderSize = 1;
+        _browseIconButton.FlatAppearance.BorderColor = _colorScheme.BorderColor;
+        _browseIconButton.Click += OnBrowseIconClick;
+        this.Controls.Add(_browseIconButton);
+
+        _clearIconButton = new Button
+        {
+            Text = "Clear",
+            Location = new Point(this.ClientSize.Width - padding - 55, currentY),
+            Size = new Size(55, 25),
+            BackColor = _colorScheme.ButtonBackColor,
+            ForeColor = _colorScheme.PrimaryTextColor,
+            FlatStyle = FlatStyle.Flat
+        };
+        _clearIconButton.FlatAppearance.BorderSize = 1;
+        _clearIconButton.FlatAppearance.BorderColor = _colorScheme.BorderColor;
+        _clearIconButton.Click += (s, e) => { _iconPathTextBox.Text = ""; };
+        this.Controls.Add(_clearIconButton);
+
+        currentY += 35;
+
+        var iconHelpLabel = new Label
+        {
+            Text = "Leave empty to use default satellite marker",
+            Location = new Point(controlLeft, currentY),
+            Size = new Size(controlWidth, 15),
+            ForeColor = _colorScheme.SecondaryTextColor,
+            Font = new Font("Segoe UI", 8F)
+        };
+        this.Controls.Add(iconHelpLabel);
+
+        // Buttons at bottom
+        currentY = this.ClientSize.Height - 50;
+
+        _saveButton = new Button
+        {
+            Text = "Save Changes",
+            Location = new Point(this.ClientSize.Width - padding - 190, currentY),
+            Size = new Size(95, 30),
+            BackColor = _colorScheme.AccentColor,
+            ForeColor = Color.White,
+            FlatStyle = FlatStyle.Flat
+        };
+        _saveButton.FlatAppearance.BorderSize = 0;
+        _saveButton.Click += OnSaveClick;
+        this.Controls.Add(_saveButton);
+
+        _cancelButton = new Button
+        {
+            Text = "Cancel",
+            Location = new Point(this.ClientSize.Width - padding - 85, currentY),
+            Size = new Size(70, 30),
+            BackColor = _colorScheme.ButtonBackColor,
+            ForeColor = _colorScheme.PrimaryTextColor,
+            FlatStyle = FlatStyle.Flat
+        };
+        _cancelButton.FlatAppearance.BorderSize = 1;
+        _cancelButton.FlatAppearance.BorderColor = _colorScheme.BorderColor;
+        _cancelButton.Click += (s, e) => { this.DialogResult = DialogResult.Cancel; this.Close(); };
+        this.Controls.Add(_cancelButton);
+    }
+
+    /// <summary>
+    /// Loads the satellite data into the form controls.
+    /// </summary>
+    private void LoadSatelliteData()
+    {
+        _nameTextBox.Text = _satellite.Name;
+        _enabledCheckBox.Checked = _satellite.Enabled;
+        _showOrbitCheckBox.Checked = _satellite.ShowOrbit;
+        _iconPathTextBox.Text = _satellite.IconPath ?? "";
+
+        _infoLabel.Text = $"NORAD ID: {_satellite.NoradId}  |  Category: {_satellite.Category.ToDisplayString()}" +
+                          (_satellite.IsLagrangePoint ? "\nWarning: This satellite is at a Lagrange point" : "");
+
+        if (_satellite.IsLagrangePoint)
+        {
+            _infoLabel.ForeColor = _colorScheme.WarningColor;
+        }
+
+        SelectColor(_selectedColor);
+    }
+
+    /// <summary>
+    /// Selects a color and updates the preview.
+    /// </summary>
+    private void SelectColor(string hexColor)
+    {
+        _selectedColor = hexColor;
+        _colorPreviewPanel.BackColor = ParseHexColor(hexColor);
+    }
+
+    /// <summary>
+    /// Handler for color button click.
+    /// </summary>
+    private void OnColorButtonClick(object? sender, EventArgs e)
+    {
+        using var colorDialog = new ColorDialog
+        {
+            Color = _colorPreviewPanel.BackColor,
+            FullOpen = true
+        };
+
+        if (colorDialog.ShowDialog() == DialogResult.OK)
+        {
+            var color = colorDialog.Color;
+            _selectedColor = $"#{color.R:X2}{color.G:X2}{color.B:X2}";
+            _colorPreviewPanel.BackColor = color;
+        }
+    }
+
+    /// <summary>
+    /// Handler for browse icon button click.
+    /// </summary>
+    private void OnBrowseIconClick(object? sender, EventArgs e)
+    {
+        using var openDialog = new OpenFileDialog
+        {
+            Title = "Select Satellite Icon",
+            Filter = "Image Files|*.png;*.jpg;*.jpeg;*.bmp;*.gif|All Files|*.*",
+            FilterIndex = 1
+        };
+
+        if (openDialog.ShowDialog() == DialogResult.OK)
+        {
+            _iconPathTextBox.Text = openDialog.FileName;
+        }
+    }
+
+    /// <summary>
+    /// Handler for save button click.
+    /// </summary>
+    private void OnSaveClick(object? sender, EventArgs e)
+    {
+        if (string.IsNullOrWhiteSpace(_nameTextBox.Text))
+        {
+            MessageBox.Show("Please enter a display name for the satellite.",
+                "Validation Error", MessageBoxButtons.OK, MessageBoxIcon.Warning);
+            return;
+        }
+
+        _satellite.Name = _nameTextBox.Text.Trim();
+        _satellite.Enabled = _enabledCheckBox.Checked;
+        _satellite.ShowOrbit = _showOrbitCheckBox.Checked;
+        _satellite.Color = _selectedColor;
+        _satellite.IconPath = string.IsNullOrWhiteSpace(_iconPathTextBox.Text) ? null : _iconPathTextBox.Text;
+
+        var configManager = SatelliteConfigManager.Instance;
+        if (configManager.UpdateSatellite(_satellite))
+        {
+            WasModified = true;
+            this.DialogResult = DialogResult.OK;
+            this.Close();
+        }
+        else
+        {
+            MessageBox.Show("Failed to save satellite configuration.",
+                "Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
+        }
+    }
+
+    /// <summary>
+    /// Parses a hex color string to a Color value.
+    /// </summary>
+    private static Color ParseHexColor(string hexColor)
+    {
+        try
+        {
+            if (string.IsNullOrEmpty(hexColor))
+                return Color.White;
+
+            var hex = hexColor.TrimStart('#');
+
+            if (hex.Length == 3)
+            {
+                hex = $"{hex[0]}{hex[0]}{hex[1]}{hex[1]}{hex[2]}{hex[2]}";
+            }
+
+            if (hex.Length != 6)
+                return Color.White;
+
+            var r = Convert.ToInt32(hex.Substring(0, 2), 16);
+            var g = Convert.ToInt32(hex.Substring(2, 2), 16);
+            var b = Convert.ToInt32(hex.Substring(4, 2), 16);
+
+            return Color.FromArgb(r, g, b);
+        }
+        catch
+        {
+            return Color.White;
+        }
+    }
+}

--- a/Settings/SettingsForm.Designer.cs
+++ b/Settings/SettingsForm.Designer.cs
@@ -1,3 +1,5 @@
+using WorldMapWallpaper.Shared;
+
 namespace WorldMapWallpaper.Settings
 {
     partial class SettingsForm
@@ -205,14 +207,11 @@ namespace WorldMapWallpaper.Settings
                 BackColor = SystemColors.Window,
                 ForeColor = Color.Black
             };
-            _updateIntervalCombo.Items.Add("Every 5 minutes");
-            _updateIntervalCombo.Items.Add("Every 15 minutes");
-            _updateIntervalCombo.Items.Add("Every 30 minutes");
-            _updateIntervalCombo.Items.Add("Every hour");
-            _updateIntervalCombo.Items.Add("Every 2 hours");
-            _updateIntervalCombo.Items.Add("Every 6 hours");
-            _updateIntervalCombo.Items.Add("Every 12 hours");
-            _updateIntervalCombo.Items.Add("Daily");
+            _updateIntervalCombo.Items.Add(new ComboBoxItem("Every 5 minutes", UpdateInterval.Every5Minutes));
+            _updateIntervalCombo.Items.Add(new ComboBoxItem("Every 10 minutes", UpdateInterval.Every10Minutes));
+            _updateIntervalCombo.Items.Add(new ComboBoxItem("Every 15 minutes", UpdateInterval.Every15Minutes));
+            _updateIntervalCombo.Items.Add(new ComboBoxItem("Every 30 minutes", UpdateInterval.Every30Minutes));
+            _updateIntervalCombo.Items.Add(new ComboBoxItem("Every hour", UpdateInterval.Hourly));
             _updateIntervalCombo.SelectedIndex = 0;
             _updateGroup.Controls.Add(_updateIntervalCombo);
 
@@ -259,8 +258,9 @@ namespace WorldMapWallpaper.Settings
                 BackColor = SystemColors.Window,
                 ForeColor = Color.Black
             };
-            _resolutionModeCombo.Items.Add("Auto-detect");
-            _resolutionModeCombo.Items.Add("Custom");
+            _resolutionModeCombo.Items.Add(new ComboBoxItem("Original (1920x1080)", ResolutionMode.None));
+            _resolutionModeCombo.Items.Add(new ComboBoxItem("Fit to Screen", ResolutionMode.Fit));
+            _resolutionModeCombo.Items.Add(new ComboBoxItem("Stretch to Screen", ResolutionMode.Stretch));
             _resolutionModeCombo.SelectedIndex = 0;
             _resolutionGroup.Controls.Add(_resolutionModeCombo);
 
@@ -398,7 +398,7 @@ namespace WorldMapWallpaper.Settings
             // Satellites list
             _listLabel = new Label
             {
-                Text = "Configured Satellites (drag to reorder priority):",
+                Text = "Configured Satellites (use Move Up/Down to reorder priority):",
                 Location = new Point(10, 45),
                 Size = new Size(300, 18),
                 Font = new Font("Segoe UI", 9F),

--- a/Settings/SettingsForm.Designer.cs
+++ b/Settings/SettingsForm.Designer.cs
@@ -7,6 +7,57 @@ namespace WorldMapWallpaper.Settings
         /// </summary>
         private System.ComponentModel.IContainer components = null;
 
+        // Tab Control
+        private TabControl _tabControl = null!;
+        private TabPage _generalTab = null!;
+        private TabPage _satellitesTab = null!;
+        private TabPage _aboutTab = null!;
+
+        // General Tab Controls
+        private CheckBox _issCheckBox = null!;
+        private CheckBox _timeZonesCheckBox = null!;
+        private CheckBox _politicalMapCheckBox = null!;
+        private ComboBox _updateIntervalCombo = null!;
+        private Label _taskStatusLabel = null!;
+        private ComboBox _resolutionModeCombo = null!;
+        private TextBox _customWidthTextBox = null!;
+        private TextBox _customHeightTextBox = null!;
+        private Label _detectedResolutionLabel = null!;
+
+        // Satellites Tab Controls
+        private CheckBox _satelliteTrackingCheckBox = null!;
+        private ListBox _satelliteListBox = null!;
+        private Button _addSatelliteButton = null!;
+        private Button _editSatelliteButton = null!;
+        private Button _removeSatelliteButton = null!;
+        private Button _moveUpButton = null!;
+        private Button _moveDownButton = null!;
+        private NumericUpDown _maxVisibleUpDown = null!;
+        private Label _satelliteCountLabel = null!;
+
+        // Bottom Buttons
+        private Button _previewButton = null!;
+        private Button _resetButton = null!;
+        private Button _closeButton = null!;
+        // Additional controls for proper designer support
+        private Label _headerLabel = null!;
+        private GroupBox _visualGroup = null!;
+        private GroupBox _updateGroup = null!;
+        private Label _intervalLabel = null!;
+        private GroupBox _resolutionGroup = null!;
+        private Label _resModeLabel = null!;
+        private Label _customLabel = null!;
+        private Label _xLabel = null!;
+        private Label _helpLabel = null!;
+        private Label _listLabel = null!;
+        private Label _maxVisibleLabel = null!;
+        private Label _infoLabel = null!;
+        private Label _titleLabel = null!;
+        private Label _versionLabel = null!;
+        private Label _descLabel = null!;
+        private Label _featuresLabel = null!;
+        private Label _copyrightLabel = null!;
+
         /// <summary>
         /// Clean up any resources being used.
         /// </summary>
@@ -43,8 +94,537 @@ namespace WorldMapWallpaper.Settings
             this.ShowInTaskbar = true;
             this.StartPosition = System.Windows.Forms.FormStartPosition.CenterScreen;
             this.Text = "World Map Wallpaper Settings";
+            this.Font = new Font("Segoe UI", 9F);
+
+            var padding = 15;
+
+            // Header
+            _headerLabel = new Label
+            {
+                Text = "World Map Wallpaper Settings",
+                Font = new Font("Segoe UI", 14F, FontStyle.Bold),
+                Location = new Point(padding, 15),
+                Size = new Size(this.ClientSize.Width - 2 * padding, 28),
+                ForeColor = Color.Blue,
+                BackColor = Color.Transparent
+            };
+            this.Controls.Add(_headerLabel);
+
+            // Tab Control
+            _tabControl = new TabControl
+            {
+                Location = new Point(padding, 55),
+                Size = new Size(this.ClientSize.Width - 2 * padding, 490),
+                Font = new Font("Segoe UI", 9F)
+            };
+            this.Controls.Add(_tabControl);
+
+            // Create tabs
+            _generalTab = new TabPage
+            {
+                Text = "General",
+                BackColor = Color.White,
+                Padding = new Padding(10)
+            };
+            _tabControl.TabPages.Add(_generalTab);
+
+            // Visual Elements Group
+            _visualGroup = new GroupBox
+            {
+                Text = "Visual Elements",
+                Font = new Font("Segoe UI", 9F, FontStyle.Bold),
+                Location = new Point(5, 10),
+                Size = new Size(_generalTab.ClientSize.Width - 10, 105),
+                ForeColor = Color.Black,
+                BackColor = SystemColors.Control
+            };
+            _generalTab.Controls.Add(_visualGroup);
+
+            _issCheckBox = new CheckBox
+            {
+                Text = "Show International Space Station (legacy - see Satellites tab)",
+                Location = new Point(12, 22),
+                Size = new Size(_visualGroup.Width - 24, 20),
+                Font = new Font("Segoe UI", 9F),
+                ForeColor = Color.Gray,
+                BackColor = Color.Transparent
+            };
+            _visualGroup.Controls.Add(_issCheckBox);
+
+            _timeZonesCheckBox = new CheckBox
+            {
+                Text = "Show time zone clocks around the world",
+                Location = new Point(12, 47),
+                Size = new Size(_visualGroup.Width - 24, 20),
+                Font = new Font("Segoe UI", 9F),
+                ForeColor = Color.Black,
+                BackColor = Color.Transparent
+            };
+            _visualGroup.Controls.Add(_timeZonesCheckBox);
+
+            _politicalMapCheckBox = new CheckBox
+            {
+                Text = "Show political boundaries and country borders",
+                Location = new Point(12, 72),
+                Size = new Size(_visualGroup.Width - 24, 20),
+                Font = new Font("Segoe UI", 9F),
+                ForeColor = Color.Black,
+                BackColor = Color.Transparent
+            };
+            _visualGroup.Controls.Add(_politicalMapCheckBox);
+
+            // Update Settings Group
+            _updateGroup = new GroupBox
+            {
+                Text = "Update Settings",
+                Font = new Font("Segoe UI", 9F, FontStyle.Bold),
+                Location = new Point(5, 125),
+                Size = new Size(_generalTab.ClientSize.Width - 10, 90),
+                ForeColor = Color.Black,
+                BackColor = SystemColors.Control
+            };
+            _generalTab.Controls.Add(_updateGroup);
+
+            _intervalLabel = new Label
+            {
+                Text = "Update Frequency:",
+                Location = new Point(12, 25),
+                Size = new Size(110, 20),
+                Font = new Font("Segoe UI", 9F),
+                ForeColor = Color.Black,
+                BackColor = Color.Transparent
+            };
+            _updateGroup.Controls.Add(_intervalLabel);
+
+            _updateIntervalCombo = new ComboBox
+            {
+                Location = new Point(125, 22),
+                Size = new Size(_updateGroup.Width - 140, 23),
+                DropDownStyle = ComboBoxStyle.DropDownList,
+                Font = new Font("Segoe UI", 9F),
+                BackColor = SystemColors.Window,
+                ForeColor = Color.Black
+            };
+            _updateIntervalCombo.Items.Add("Every 5 minutes");
+            _updateIntervalCombo.Items.Add("Every 15 minutes");
+            _updateIntervalCombo.Items.Add("Every 30 minutes");
+            _updateIntervalCombo.Items.Add("Every hour");
+            _updateIntervalCombo.Items.Add("Every 2 hours");
+            _updateIntervalCombo.Items.Add("Every 6 hours");
+            _updateIntervalCombo.Items.Add("Every 12 hours");
+            _updateIntervalCombo.Items.Add("Daily");
+            _updateIntervalCombo.SelectedIndex = 0;
+            _updateGroup.Controls.Add(_updateIntervalCombo);
+
+            _taskStatusLabel = new Label
+            {
+                Text = "Scheduled task is enabled",
+                Location = new Point(12, 55),
+                Size = new Size(_updateGroup.Width - 24, 25),
+                Font = new Font("Segoe UI", 8F),
+                ForeColor = Color.Green,
+                BackColor = Color.Transparent
+            };
+            _updateGroup.Controls.Add(_taskStatusLabel);
+
+            // Resolution Settings Group
+            _resolutionGroup = new GroupBox
+            {
+                Text = "Resolution Settings",
+                Font = new Font("Segoe UI", 9F, FontStyle.Bold),
+                Location = new Point(5, 225),
+                Size = new Size(_generalTab.ClientSize.Width - 10, 115),
+                ForeColor = Color.Black,
+                BackColor = SystemColors.Control
+            };
+            _generalTab.Controls.Add(_resolutionGroup);
+
+            _resModeLabel = new Label
+            {
+                Text = "Resolution Mode:",
+                Location = new Point(12, 22),
+                Size = new Size(105, 20),
+                Font = new Font("Segoe UI", 9F),
+                ForeColor = Color.Black,
+                BackColor = Color.Transparent
+            };
+            _resolutionGroup.Controls.Add(_resModeLabel);
+
+            _resolutionModeCombo = new ComboBox
+            {
+                Location = new Point(120, 19),
+                Size = new Size(_resolutionGroup.Width - 135, 23),
+                DropDownStyle = ComboBoxStyle.DropDownList,
+                Font = new Font("Segoe UI", 9F),
+                BackColor = SystemColors.Window,
+                ForeColor = Color.Black
+            };
+            _resolutionModeCombo.Items.Add("Auto-detect");
+            _resolutionModeCombo.Items.Add("Custom");
+            _resolutionModeCombo.SelectedIndex = 0;
+            _resolutionGroup.Controls.Add(_resolutionModeCombo);
+
+            _detectedResolutionLabel = new Label
+            {
+                Text = "Detected: 1920 x 1080",
+                Location = new Point(12, 48),
+                Size = new Size(_resolutionGroup.Width - 24, 15),
+                Font = new Font("Segoe UI", 8F),
+                ForeColor = Color.Gray,
+                BackColor = Color.Transparent
+            };
+            _resolutionGroup.Controls.Add(_detectedResolutionLabel);
+
+            _customLabel = new Label
+            {
+                Text = "Custom (0=auto):",
+                Location = new Point(12, 70),
+                Size = new Size(105, 20),
+                Font = new Font("Segoe UI", 9F),
+                ForeColor = Color.Black,
+                BackColor = Color.Transparent
+            };
+            _resolutionGroup.Controls.Add(_customLabel);
+
+            _customWidthTextBox = new TextBox
+            {
+                Location = new Point(120, 67),
+                Size = new Size(65, 23),
+                Font = new Font("Segoe UI", 9F),
+                BackColor = SystemColors.Window,
+                ForeColor = Color.Black
+            };
+            _resolutionGroup.Controls.Add(_customWidthTextBox);
+
+            _xLabel = new Label
+            {
+                Text = "x",
+                Location = new Point(190, 70),
+                Size = new Size(15, 20),
+                Font = new Font("Segoe UI", 9F),
+                ForeColor = Color.Black,
+                BackColor = Color.Transparent
+            };
+            _resolutionGroup.Controls.Add(_xLabel);
+
+            _customHeightTextBox = new TextBox
+            {
+                Location = new Point(205, 67),
+                Size = new Size(65, 23),
+                Font = new Font("Segoe UI", 9F),
+                BackColor = SystemColors.Window,
+                ForeColor = Color.Black
+            };
+            _resolutionGroup.Controls.Add(_customHeightTextBox);
+
+            _helpLabel = new Label
+            {
+                Text = "(both 0 = auto-detect)",
+                Location = new Point(280, 70),
+                Size = new Size(130, 20),
+                Font = new Font("Segoe UI", 8F),
+                ForeColor = Color.Gray,
+                BackColor = Color.Transparent
+            };
+            _resolutionGroup.Controls.Add(_helpLabel);
+
+            // Preview Button
+            _previewButton = new Button
+            {
+                Text = "Update Wallpaper Now",
+                Location = new Point(padding, 560),
+                Size = new Size(this.ClientSize.Width - 2 * padding, 35),
+                Font = new Font("Segoe UI", 9F),
+                BackColor = Color.Blue,
+                ForeColor = Color.White,
+                FlatStyle = FlatStyle.Flat,
+                Cursor = Cursors.Hand
+            };
+            _previewButton.FlatAppearance.BorderSize = 0;
+            this.Controls.Add(_previewButton);
+
+            // Bottom buttons
+            _resetButton = new Button
+            {
+                Text = "Reset to Defaults",
+                Location = new Point(padding, 610),
+                Size = new Size(130, 30),
+                Font = new Font("Segoe UI", 9F),
+                BackColor = SystemColors.Control,
+                ForeColor = Color.Black,
+                FlatStyle = FlatStyle.Flat,
+                Cursor = Cursors.Hand
+            };
+            _resetButton.FlatAppearance.BorderSize = 1;
+            _resetButton.FlatAppearance.BorderColor = SystemColors.WindowFrame;
+            this.Controls.Add(_resetButton);
+
+            _closeButton = new Button
+            {
+                Text = "Close",
+                Location = new Point(this.ClientSize.Width - padding - 80, 610),
+                Size = new Size(80, 30),
+                Font = new Font("Segoe UI", 9F),
+                BackColor = SystemColors.Control,
+                ForeColor = Color.Black,
+                FlatStyle = FlatStyle.Flat,
+                Cursor = Cursors.Hand
+            };
+            _closeButton.FlatAppearance.BorderSize = 1;
+            _closeButton.FlatAppearance.BorderColor = SystemColors.WindowFrame;
+            this.Controls.Add(_closeButton);
+
+            // Satellites Tab
+            _satellitesTab = new TabPage
+            {
+                Text = "Satellites",
+                BackColor = Color.White,
+                Padding = new Padding(10)
+            };
+            _tabControl.TabPages.Add(_satellitesTab);
+
+            // Master enable checkbox
+            _satelliteTrackingCheckBox = new CheckBox
+            {
+                Text = "Enable satellite tracking",
+                Location = new Point(10, 10),
+                Size = new Size(200, 23),
+                Font = new Font("Segoe UI", 9F, FontStyle.Bold),
+                ForeColor = Color.Black,
+                BackColor = Color.Transparent
+            };
+            _satellitesTab.Controls.Add(_satelliteTrackingCheckBox);
+
+            // Satellites list
+            _listLabel = new Label
+            {
+                Text = "Configured Satellites (drag to reorder priority):",
+                Location = new Point(10, 45),
+                Size = new Size(300, 18),
+                Font = new Font("Segoe UI", 9F),
+                ForeColor = Color.Black,
+                BackColor = Color.Transparent
+            };
+            _satellitesTab.Controls.Add(_listLabel);
+
+            _satelliteListBox = new ListBox
+            {
+                Location = new Point(10, 67),
+                Size = new Size(320, 220),
+                BackColor = SystemColors.Window,
+                ForeColor = Color.Black,
+                BorderStyle = BorderStyle.FixedSingle,
+                SelectionMode = SelectionMode.One
+            };
+            _satellitesTab.Controls.Add(_satelliteListBox);
+
+            // Side buttons
+            _addSatelliteButton = new Button
+            {
+                Text = "Add...",
+                Location = new Point(340, 67),
+                Size = new Size(85, 28),
+                BackColor = Color.Blue,
+                ForeColor = Color.White,
+                FlatStyle = FlatStyle.Flat
+            };
+            _addSatelliteButton.FlatAppearance.BorderSize = 0;
+            _satellitesTab.Controls.Add(_addSatelliteButton);
+
+            _editSatelliteButton = new Button
+            {
+                Text = "Edit...",
+                Location = new Point(340, 102),
+                Size = new Size(85, 28),
+                BackColor = SystemColors.Control,
+                ForeColor = Color.Black,
+                FlatStyle = FlatStyle.Flat,
+                Enabled = false
+            };
+            _editSatelliteButton.FlatAppearance.BorderSize = 1;
+            _editSatelliteButton.FlatAppearance.BorderColor = SystemColors.WindowFrame;
+            _satellitesTab.Controls.Add(_editSatelliteButton);
+
+            _removeSatelliteButton = new Button
+            {
+                Text = "Remove",
+                Location = new Point(340, 137),
+                Size = new Size(85, 28),
+                BackColor = SystemColors.Control,
+                ForeColor = Color.Black,
+                FlatStyle = FlatStyle.Flat,
+                Enabled = false
+            };
+            _removeSatelliteButton.FlatAppearance.BorderSize = 1;
+            _removeSatelliteButton.FlatAppearance.BorderColor = SystemColors.WindowFrame;
+            _satellitesTab.Controls.Add(_removeSatelliteButton);
+
+            _moveUpButton = new Button
+            {
+                Text = "Move Up",
+                Location = new Point(340, 187),
+                Size = new Size(85, 28),
+                BackColor = SystemColors.Control,
+                ForeColor = Color.Black,
+                FlatStyle = FlatStyle.Flat,
+                Enabled = false
+            };
+            _moveUpButton.FlatAppearance.BorderSize = 1;
+            _moveUpButton.FlatAppearance.BorderColor = SystemColors.WindowFrame;
+            _satellitesTab.Controls.Add(_moveUpButton);
+
+            _moveDownButton = new Button
+            {
+                Text = "Move Down",
+                Location = new Point(340, 222),
+                Size = new Size(85, 28),
+                BackColor = SystemColors.Control,
+                ForeColor = Color.Black,
+                FlatStyle = FlatStyle.Flat,
+                Enabled = false
+            };
+            _moveDownButton.FlatAppearance.BorderSize = 1;
+            _moveDownButton.FlatAppearance.BorderColor = SystemColors.WindowFrame;
+            _satellitesTab.Controls.Add(_moveDownButton);
+
+            // Max visible setting
+            _maxVisibleLabel = new Label
+            {
+                Text = "Max visible satellites:",
+                Location = new Point(10, 300),
+                Size = new Size(130, 20),
+                Font = new Font("Segoe UI", 9F),
+                ForeColor = Color.Black,
+                BackColor = Color.Transparent
+            };
+            _satellitesTab.Controls.Add(_maxVisibleLabel);
+
+            _maxVisibleUpDown = new NumericUpDown
+            {
+                Location = new Point(145, 297),
+                Size = new Size(60, 23),
+                Minimum = 1,
+                Maximum = 15,
+                Value = 5,
+                BackColor = SystemColors.Window,
+                ForeColor = Color.Black
+            };
+            _satellitesTab.Controls.Add(_maxVisibleUpDown);
+
+            _satelliteCountLabel = new Label
+            {
+                Text = "0 satellites configured",
+                Location = new Point(215, 300),
+                Size = new Size(200, 20),
+                Font = new Font("Segoe UI", 8F),
+                ForeColor = Color.Gray,
+                BackColor = Color.Transparent
+            };
+            _satellitesTab.Controls.Add(_satelliteCountLabel);
+
+            // Info label
+            _infoLabel = new Label
+            {
+                Text = "Higher priority satellites (top of list) are shown first.\n" +
+                       "Double-click a satellite to edit its settings.",
+                Location = new Point(10, 332),
+                Size = new Size(_satellitesTab.ClientSize.Width - 20, 35),
+                Font = new Font("Segoe UI", 8F),
+                ForeColor = Color.Gray,
+                BackColor = Color.Transparent
+            };
+            _satellitesTab.Controls.Add(_infoLabel);
+
+            // About Tab
+            _aboutTab = new TabPage
+            {
+                Text = "About",
+                BackColor = Color.White,
+                Padding = new Padding(10)
+            };
+            _tabControl.TabPages.Add(_aboutTab);
+
+            _titleLabel = new Label
+            {
+                Text = "World Map Wallpaper",
+                Font = new Font("Segoe UI", 16F, FontStyle.Bold),
+                Location = new Point(10, 20),
+                Size = new Size(400, 30),
+                ForeColor = Color.Blue,
+                BackColor = Color.Transparent
+            };
+            _aboutTab.Controls.Add(_titleLabel);
+
+            _versionLabel = new Label
+            {
+                Text = "Version " + System.Reflection.Assembly.GetExecutingAssembly().GetName().Version.ToString(),
+                Font = new Font("Segoe UI", 10F),
+                Location = new Point(10, 60),
+                Size = new Size(400, 25),
+                ForeColor = Color.Black,
+                BackColor = Color.Transparent
+            };
+            _aboutTab.Controls.Add(_versionLabel);
+
+            _descLabel = new Label
+            {
+                Text = "Dynamic wallpaper generator featuring real-time day/night cycles,\n" +
+                       "time zone clocks, and satellite tracking with SGP4 orbital mechanics.",
+                Font = new Font("Segoe UI", 9F),
+                Location = new Point(10, 100),
+                Size = new Size(400, 45),
+                ForeColor = Color.Black,
+                BackColor = Color.Transparent
+            };
+            _aboutTab.Controls.Add(_descLabel);
+
+            _featuresLabel = new Label
+            {
+                Text = "Features:\n" +
+                       "  - Real-time day/night terminator visualization\n" +
+                       "  - Multi-satellite tracking (ISS, Hubble, etc.)\n" +
+                       "  - 24 analog clocks showing world time zones\n" +
+                       "  - Political boundaries overlay\n" +
+                       "  - Resolution scaling for different displays",
+                Font = new Font("Segoe UI", 9F),
+                Location = new Point(10, 160),
+                Size = new Size(400, 120),
+                ForeColor = Color.Black,
+                BackColor = Color.Transparent
+            };
+            _aboutTab.Controls.Add(_featuresLabel);
+
+            _copyrightLabel = new Label
+            {
+                Text = "Copyright 2023-2024. All rights reserved.",
+                Font = new Font("Segoe UI", 8F),
+                Location = new Point(10, 300),
+                Size = new Size(400, 20),
+                ForeColor = Color.Gray,
+                BackColor = Color.Transparent
+            };
+            _aboutTab.Controls.Add(_copyrightLabel);
+
             this.ResumeLayout(false);
 
+            _issCheckBox.CheckedChanged += OnSettingChanged;
+            _timeZonesCheckBox.CheckedChanged += OnSettingChanged;
+            _politicalMapCheckBox.CheckedChanged += OnSettingChanged;
+            _updateIntervalCombo.SelectedIndexChanged += OnUpdateIntervalChanged;
+            _resolutionModeCombo.SelectedIndexChanged += OnResolutionModeChanged;
+            _customWidthTextBox.TextChanged += OnCustomResolutionChanged;
+            _customHeightTextBox.TextChanged += OnCustomResolutionChanged;
+            _satelliteTrackingCheckBox.CheckedChanged += OnSatelliteTrackingChanged;
+            _satelliteListBox.SelectedIndexChanged += OnSatelliteSelectionChanged;
+            _satelliteListBox.DoubleClick += OnSatelliteDoubleClick;
+            _addSatelliteButton.Click += OnAddSatelliteClick;
+            _editSatelliteButton.Click += OnEditSatelliteClick;
+            _removeSatelliteButton.Click += OnRemoveSatelliteClick;
+            _moveUpButton.Click += OnMoveUpClick;
+            _moveDownButton.Click += OnMoveDownClick;
+            _maxVisibleUpDown.ValueChanged += OnMaxVisibleChanged;
+            _previewButton.Click += OnPreviewClick;
+            _resetButton.Click += OnResetClick;
         }
 
         #endregion

--- a/Settings/SettingsForm.cs
+++ b/Settings/SettingsForm.cs
@@ -1,4 +1,6 @@
 using WorldMapWallpaper.Shared;
+using WorldMapWallpaper.Shared.Models;
+using WorldMapWallpaper.Shared.Services;
 using System.Diagnostics;
 using System.Reflection;
 
@@ -6,7 +8,7 @@ namespace WorldMapWallpaper.Settings;
 
 /// <summary>
 /// The main settings form for World Map Wallpaper.
-/// Provides a modern-looking interface for configuring wallpaper options with system theme support.
+/// Provides a modern tabbed interface for configuring wallpaper and satellite options.
 /// </summary>
 public partial class SettingsForm : Form
 {
@@ -14,99 +16,37 @@ public partial class SettingsForm : Form
     /// Monitors wallpaper changes to detect when the user switches away from our wallpaper.
     /// </summary>
     private WallpaperMonitor? _wallpaperMonitor;
-    
+
     /// <summary>
-    /// The color scheme used for theming the form controls based on the current system theme.
+    /// The color scheme used for theming the form controls.
     /// </summary>
     private readonly ColorScheme _colorScheme = null!;
-    
+
     /// <summary>
-    /// The system tray icon that provides quick access to settings and wallpaper updates.
+    /// The system tray icon for quick access.
     /// </summary>
     private NotifyIcon? _notifyIcon;
-    
+
     /// <summary>
     /// Indicates whether the form should start minimized to the system tray.
     /// </summary>
     private readonly bool _minimizeToTray = false;
 
     /// <summary>
-    /// Checkbox control for enabling/disabling the International Space Station overlay.
+    /// Initializes a new instance of the SettingsForm class.
     /// </summary>
-    private CheckBox _issCheckBox = null!;
-    
-    /// <summary>
-    /// Checkbox control for enabling/disabling the time zones overlay.
-    /// </summary>
-    private CheckBox _timeZonesCheckBox = null!;
-    
-    /// <summary>
-    /// Checkbox control for enabling/disabling the political map overlay.
-    /// </summary>
-    private CheckBox _politicalMapCheckBox = null!;
-    
-    /// <summary>
-    /// Combo box for selecting the wallpaper update frequency.
-    /// </summary>
-    private ComboBox _updateIntervalCombo = null!;
-    
-    /// <summary>
-    /// Button for immediately updating the wallpaper with current settings.
-    /// </summary>
-    private Button _previewButton = null!;
-    
-    /// <summary>
-    /// Button for resetting all settings to their default values.
-    /// </summary>
-    private Button _resetButton = null!;
-    
-    /// <summary>
-    /// Button for closing the settings form.
-    /// </summary>
-    private Button _closeButton = null!;
-    
-    /// <summary>
-    /// Label displaying the current status of the scheduled task.
-    /// </summary>
-    private Label _taskStatusLabel = null!;
-
-    /// <summary>
-    /// Combo box for selecting the resolution scaling mode.
-    /// </summary>
-    private ComboBox _resolutionModeCombo = null!;
-
-    /// <summary>
-    /// Text box for custom resolution width.
-    /// </summary>
-    private TextBox _customWidthTextBox = null!;
-
-    /// <summary>
-    /// Text box for custom resolution height.
-    /// </summary>
-    private TextBox _customHeightTextBox = null!;
-
-    /// <summary>
-    /// Label showing detected screen resolution.
-    /// </summary>
-    private Label _detectedResolutionLabel = null!;
-
-    /// <summary>
-    /// Initializes a new instance of the <see cref="SettingsForm"/> class.
-    /// </summary>
-    /// <param name="minimizeToTray">If true, the form starts minimized to the system tray; otherwise, it appears normally.</param>
+    /// <param name="minimizeToTray">If true, the form starts minimized to the system tray.</param>
     public SettingsForm(bool minimizeToTray = false)
     {
-        // Get current theme before initializing components
         _colorScheme = ThemeManager.GetCurrentColorScheme();
-        
+
         InitializeComponent();
-        InitializeFormSettings();
+        WireEvents();
         ApplyTheme();
-        InitializeControls();
         InitializeTrayIcon();
         LoadSettings();
         StartWallpaperMonitoring();
-        
+
         if (minimizeToTray)
         {
             this.WindowState = FormWindowState.Minimized;
@@ -116,345 +56,177 @@ public partial class SettingsForm : Form
     }
 
     /// <summary>
-    /// Applies additional form settings after designer initialization.
+    /// Wires up event handlers for the form controls.
     /// </summary>
-    private void InitializeFormSettings()
+    private void WireEvents()
     {
-        // Set modern appearance
-        this.Font = new Font("Segoe UI", 9F);
+        _closeButton.Click += (s, e) => MinimizeToTray();
     }
 
     /// <summary>
-    /// Applies the current theme colors to the form's background and text.
+    /// Applies the current theme colors to the form.
     /// </summary>
     private void ApplyTheme()
     {
-        // Apply theme to the form
-        this.BackColor = _colorScheme.BackgroundColor;
-        this.ForeColor = _colorScheme.PrimaryTextColor;
+        BackColor = _colorScheme.BackgroundColor;
+        ForeColor = _colorScheme.PrimaryTextColor;
+
+        ApplyThemeToControl(this);
+        ApplyThemeToButtons();
+        ApplyThemeToTabPages();
+        UpdateAboutVersionLabel();
     }
 
-    /// <summary>
-    /// Creates and configures all the form controls including labels, checkboxes, buttons, and group boxes.
-    /// Applies theming and sets up event handlers for user interactions.
-    /// </summary>
-    private void InitializeControls()
+    private void ApplyThemeToControl(Control control)
     {
-        var padding = 20;
-        var currentY = padding;
-
-        // Header
-        var headerLabel = new Label
+        switch (control)
         {
-            Text = "World Map Wallpaper Settings",
-            Font = new Font("Segoe UI", 16F, FontStyle.Bold),
-            Location = new Point(padding, currentY),
-            Size = new Size(this.ClientSize.Width - 2 * padding, 32),
-            ForeColor = _colorScheme.AccentColor,
-            BackColor = Color.Transparent
-        };
-        this.Controls.Add(headerLabel);
-        currentY += 50;
+            case TabPage tabPage:
+                tabPage.BackColor = _colorScheme.BackgroundColor;
+                tabPage.ForeColor = _colorScheme.PrimaryTextColor;
+                break;
 
-        var subtitleLabel = new Label
-        {
-            Text = "Configure your dynamic wallpaper preferences",
-            Font = new Font("Segoe UI", 9F),
-            Location = new Point(padding, currentY),
-            Size = new Size(this.ClientSize.Width - 2 * padding, 20),
-            ForeColor = _colorScheme.SecondaryTextColor,
-            BackColor = Color.Transparent
-        };
-        this.Controls.Add(subtitleLabel);
-        currentY += 40;
+            case GroupBox groupBox:
+                groupBox.BackColor = _colorScheme.GroupBoxBackColor;
+                groupBox.ForeColor = _colorScheme.PrimaryTextColor;
+                break;
 
-        // Visual Elements Group
-        var visualGroup = new GroupBox
-        {
-            Text = "Visual Elements",
-            Font = new Font("Segoe UI", 9F, FontStyle.Bold),
-            Location = new Point(padding, currentY),
-            Size = new Size(this.ClientSize.Width - 2 * padding, 120),
-            ForeColor = _colorScheme.PrimaryTextColor,
-            BackColor = _colorScheme.GroupBoxBackColor
-        };
-        this.Controls.Add(visualGroup);
+            case TextBox textBox:
+                textBox.BackColor = _colorScheme.SurfaceColor;
+                textBox.ForeColor = _colorScheme.PrimaryTextColor;
+                break;
 
-        _issCheckBox = new CheckBox
-        {
-            Text = "Show International Space Station position and orbit",
-            Location = new Point(15, 25),
-            Size = new Size(visualGroup.Width - 30, 23),
-            Checked = true,
-            Font = new Font("Segoe UI", 9F),
-            ForeColor = _colorScheme.PrimaryTextColor,
-            BackColor = Color.Transparent
-        };
-        _issCheckBox.CheckedChanged += OnSettingChanged;
-        visualGroup.Controls.Add(_issCheckBox);
+            case ListBox listBox:
+                listBox.BackColor = _colorScheme.SurfaceColor;
+                listBox.ForeColor = _colorScheme.PrimaryTextColor;
+                break;
 
-        _timeZonesCheckBox = new CheckBox
-        {
-            Text = "Show time zone clocks around the world",
-            Location = new Point(15, 50),
-            Size = new Size(visualGroup.Width - 30, 23),
-            Checked = true,
-            Font = new Font("Segoe UI", 9F),
-            ForeColor = _colorScheme.PrimaryTextColor,
-            BackColor = Color.Transparent
-        };
-        _timeZonesCheckBox.CheckedChanged += OnSettingChanged;
-        visualGroup.Controls.Add(_timeZonesCheckBox);
+            case ComboBox comboBox:
+                comboBox.BackColor = _colorScheme.SurfaceColor;
+                comboBox.ForeColor = _colorScheme.PrimaryTextColor;
+                break;
 
-        _politicalMapCheckBox = new CheckBox
-        {
-            Text = "Show political boundaries and country borders",
-            Location = new Point(15, 75),
-            Size = new Size(visualGroup.Width - 30, 23),
-            Checked = true,
-            Font = new Font("Segoe UI", 9F),
-            ForeColor = _colorScheme.PrimaryTextColor,
-            BackColor = Color.Transparent
-        };
-        _politicalMapCheckBox.CheckedChanged += OnSettingChanged;
-        visualGroup.Controls.Add(_politicalMapCheckBox);
+            case NumericUpDown numericUpDown:
+                numericUpDown.BackColor = _colorScheme.SurfaceColor;
+                numericUpDown.ForeColor = _colorScheme.PrimaryTextColor;
+                break;
 
-        currentY += 140;
+            case CheckBox checkBox:
+                checkBox.BackColor = Color.Transparent;
+                checkBox.ForeColor = checkBox.Enabled ? _colorScheme.PrimaryTextColor : _colorScheme.SecondaryTextColor;
+                break;
 
-        // Update Settings Group
-        var updateGroup = new GroupBox
-        {
-            Text = "Update Settings",
-            Font = new Font("Segoe UI", 9F, FontStyle.Bold),
-            Location = new Point(padding, currentY),
-            Size = new Size(this.ClientSize.Width - 2 * padding, 100),
-            ForeColor = _colorScheme.PrimaryTextColor,
-            BackColor = _colorScheme.GroupBoxBackColor
-        };
-        this.Controls.Add(updateGroup);
+            case Label label:
+                ApplyThemeToLabel(label);
+                break;
 
-        var intervalLabel = new Label
-        {
-            Text = "Update Frequency:",
-            Location = new Point(15, 30),
-            Size = new Size(120, 23),
-            Font = new Font("Segoe UI", 9F),
-            ForeColor = _colorScheme.PrimaryTextColor,
-            BackColor = Color.Transparent
-        };
-        updateGroup.Controls.Add(intervalLabel);
+            case Button:
+                // Buttons are themed in a dedicated pass so primary actions stay accented.
+                break;
 
-        _updateIntervalCombo = new ComboBox
-        {
-            Location = new Point(140, 27),
-            Size = new Size(updateGroup.Width - 155, 23),
-            DropDownStyle = ComboBoxStyle.DropDownList,
-            Font = new Font("Segoe UI", 9F),
-            BackColor = _colorScheme.SurfaceColor,
-            ForeColor = _colorScheme.PrimaryTextColor
-        };
-
-        // Populate combo box
-        foreach (var interval in Enum.GetValues<UpdateInterval>())
-        {
-            _updateIntervalCombo.Items.Add(new ComboBoxItem(interval.ToDisplayString(), interval));
+            default:
+                control.BackColor = _colorScheme.BackgroundColor;
+                control.ForeColor = _colorScheme.PrimaryTextColor;
+                break;
         }
-        _updateIntervalCombo.SelectedIndexChanged += OnUpdateIntervalChanged;
-        updateGroup.Controls.Add(_updateIntervalCombo);
 
-        var infoLabel = new Label
+        foreach (Control child in control.Controls)
         {
-            Text = "More frequent updates ensure accurate day/night cycles.",
-            Location = new Point(15, 60),
-            Size = new Size(updateGroup.Width - 30, 15),
-            Font = new Font("Segoe UI", 8F),
-            ForeColor = _colorScheme.SecondaryTextColor,
-            BackColor = Color.Transparent
-        };
-        updateGroup.Controls.Add(infoLabel);
-
-        // Add task status label
-        _taskStatusLabel = new Label
-        {
-            Text = GetTaskStatusText(),
-            Location = new Point(15, 75),
-            Size = new Size(updateGroup.Width - 30, 15),
-            Font = new Font("Segoe UI", 8F),
-            ForeColor = TaskManager.IsTaskEnabled() ? _colorScheme.SuccessColor : _colorScheme.ErrorColor,
-            BackColor = Color.Transparent
-        };
-        updateGroup.Controls.Add(_taskStatusLabel);
-
-        currentY += 120;
-
-        // Resolution Settings Group
-        var resolutionGroup = new GroupBox
-        {
-            Text = "Resolution Settings",
-            Font = new Font("Segoe UI", 9F, FontStyle.Bold),
-            Location = new Point(padding, currentY),
-            Size = new Size(this.ClientSize.Width - 2 * padding, 130),
-            ForeColor = _colorScheme.PrimaryTextColor,
-            BackColor = _colorScheme.GroupBoxBackColor
-        };
-        this.Controls.Add(resolutionGroup);
-
-        var resolutionModeLabel = new Label
-        {
-            Text = "Resolution Mode:",
-            Location = new Point(15, 25),
-            Size = new Size(110, 23),
-            Font = new Font("Segoe UI", 9F),
-            ForeColor = _colorScheme.PrimaryTextColor,
-            BackColor = Color.Transparent
-        };
-        resolutionGroup.Controls.Add(resolutionModeLabel);
-
-        _resolutionModeCombo = new ComboBox
-        {
-            Location = new Point(130, 22),
-            Size = new Size(resolutionGroup.Width - 145, 23),
-            DropDownStyle = ComboBoxStyle.DropDownList,
-            Font = new Font("Segoe UI", 9F),
-            BackColor = _colorScheme.SurfaceColor,
-            ForeColor = _colorScheme.PrimaryTextColor
-        };
-
-        // Populate resolution mode combo box
-        foreach (var mode in Enum.GetValues<ResolutionMode>())
-        {
-            _resolutionModeCombo.Items.Add(new ComboBoxItem(mode.ToDisplayString(), mode));
+            ApplyThemeToControl(child);
         }
-        _resolutionModeCombo.SelectedIndexChanged += OnResolutionModeChanged;
-        resolutionGroup.Controls.Add(_resolutionModeCombo);
+    }
 
-        // Detected resolution display
-        _detectedResolutionLabel = new Label
+    private void ApplyThemeToLabel(Label label)
+    {
+        label.BackColor = Color.Transparent;
+
+        if (ReferenceEquals(label, _headerLabel) || ReferenceEquals(label, _titleLabel))
         {
-            Text = GetDetectedResolutionText(),
-            Location = new Point(15, 52),
-            Size = new Size(resolutionGroup.Width - 30, 15),
-            Font = new Font("Segoe UI", 8F),
-            ForeColor = _colorScheme.SecondaryTextColor,
-            BackColor = Color.Transparent
-        };
-        resolutionGroup.Controls.Add(_detectedResolutionLabel);
+            label.ForeColor = _colorScheme.AccentColor;
+            return;
+        }
 
-        // Custom resolution inputs
-        var customResLabel = new Label
+        if (ReferenceEquals(label, _taskStatusLabel))
         {
-            Text = "Custom (0 = auto):",
-            Location = new Point(15, 75),
-            Size = new Size(110, 23),
-            Font = new Font("Segoe UI", 9F),
-            ForeColor = _colorScheme.PrimaryTextColor,
-            BackColor = Color.Transparent
-        };
-        resolutionGroup.Controls.Add(customResLabel);
+            label.ForeColor = TaskManager.IsTaskEnabled() ? _colorScheme.SuccessColor : _colorScheme.WarningColor;
+            return;
+        }
 
-        _customWidthTextBox = new TextBox
+        if (ReferenceEquals(label, _detectedResolutionLabel) ||
+            ReferenceEquals(label, _helpLabel) ||
+            ReferenceEquals(label, _satelliteCountLabel) ||
+            ReferenceEquals(label, _infoLabel) ||
+            ReferenceEquals(label, _copyrightLabel))
         {
-            Location = new Point(130, 72),
-            Size = new Size(70, 23),
-            Font = new Font("Segoe UI", 9F),
-            BackColor = _colorScheme.SurfaceColor,
-            ForeColor = _colorScheme.PrimaryTextColor,
-            Text = "0"
-        };
-        _customWidthTextBox.TextChanged += OnCustomResolutionChanged;
-        resolutionGroup.Controls.Add(_customWidthTextBox);
+            label.ForeColor = _colorScheme.SecondaryTextColor;
+            return;
+        }
 
-        var xLabel = new Label
+        label.ForeColor = _colorScheme.PrimaryTextColor;
+    }
+
+    private void ApplyThemeToButtons()
+    {
+        ApplyButtonTheme(_previewButton, primary: true);
+        ApplyButtonTheme(_addSatelliteButton, primary: true);
+        ApplyButtonTheme(_resetButton);
+        ApplyButtonTheme(_closeButton);
+        ApplyButtonTheme(_editSatelliteButton);
+        ApplyButtonTheme(_removeSatelliteButton);
+        ApplyButtonTheme(_moveUpButton);
+        ApplyButtonTheme(_moveDownButton);
+    }
+
+    private void ApplyButtonTheme(Button? button, bool primary = false)
+    {
+        if (button == null)
+            return;
+
+        button.FlatStyle = FlatStyle.Flat;
+
+        if (primary && button.Enabled)
         {
-            Text = "x",
-            Location = new Point(205, 75),
-            Size = new Size(15, 23),
-            Font = new Font("Segoe UI", 9F),
-            ForeColor = _colorScheme.PrimaryTextColor,
-            BackColor = Color.Transparent
-        };
-        resolutionGroup.Controls.Add(xLabel);
-
-        _customHeightTextBox = new TextBox
+            button.BackColor = _colorScheme.AccentColor;
+            button.ForeColor = Color.White;
+            button.FlatAppearance.BorderSize = 0;
+        }
+        else
         {
-            Location = new Point(220, 72),
-            Size = new Size(70, 23),
-            Font = new Font("Segoe UI", 9F),
-            BackColor = _colorScheme.SurfaceColor,
-            ForeColor = _colorScheme.PrimaryTextColor,
-            Text = "0"
-        };
-        _customHeightTextBox.TextChanged += OnCustomResolutionChanged;
-        resolutionGroup.Controls.Add(_customHeightTextBox);
+            button.BackColor = _colorScheme.ButtonBackColor;
+            button.ForeColor = button.Enabled ? _colorScheme.PrimaryTextColor : _colorScheme.SecondaryTextColor;
+            button.FlatAppearance.BorderSize = 1;
+            button.FlatAppearance.BorderColor = _colorScheme.BorderColor;
+        }
+    }
 
-        var customHelpLabel = new Label
+    private void ApplyThemeToTabPages()
+    {
+        if (_tabControl == null)
+            return;
+
+        _tabControl.BackColor = _colorScheme.BackgroundColor;
+        _tabControl.ForeColor = _colorScheme.PrimaryTextColor;
+
+        foreach (TabPage page in _tabControl.TabPages)
         {
-            Text = "Set both to 0 to use detected screen resolution",
-            Location = new Point(15, 100),
-            Size = new Size(resolutionGroup.Width - 30, 15),
-            Font = new Font("Segoe UI", 8F),
-            ForeColor = _colorScheme.SecondaryTextColor,
-            BackColor = Color.Transparent
-        };
-        resolutionGroup.Controls.Add(customHelpLabel);
+            page.BackColor = _colorScheme.BackgroundColor;
+            page.ForeColor = _colorScheme.PrimaryTextColor;
+        }
+    }
 
-        currentY += 150;
+    private void UpdateAboutVersionLabel()
+    {
+        if (_versionLabel == null)
+            return;
 
-        // Preview Button
-        _previewButton = new Button
-        {
-            Text = "Update Wallpaper Now",
-            Location = new Point(padding, currentY),
-            Size = new Size(this.ClientSize.Width - 2 * padding, 35),
-            Font = new Font("Segoe UI", 9F),
-            BackColor = _colorScheme.AccentColor,
-            ForeColor = Color.White,
-            FlatStyle = FlatStyle.Flat,
-            Cursor = Cursors.Hand
-        };
-        _previewButton.FlatAppearance.BorderSize = 0;
-        _previewButton.Click += OnPreviewClick;
-        this.Controls.Add(_previewButton);
-        currentY += 50;
-
-        // Bottom buttons
-        _resetButton = new Button
-        {
-            Text = "Reset to Defaults",
-            Location = new Point(padding, currentY),
-            Size = new Size(150, 30),
-            Font = new Font("Segoe UI", 9F),
-            BackColor = _colorScheme.ButtonBackColor,
-            ForeColor = _colorScheme.PrimaryTextColor,
-            FlatStyle = FlatStyle.Flat,
-            Cursor = Cursors.Hand
-        };
-        _resetButton.FlatAppearance.BorderSize = 1;
-        _resetButton.FlatAppearance.BorderColor = _colorScheme.BorderColor;
-        _resetButton.Click += OnResetClick;
-        this.Controls.Add(_resetButton);
-
-
-        _closeButton = new Button
-        {
-            Text = "Close",
-            Location = new Point(this.ClientSize.Width - padding - 80, currentY),
-            Size = new Size(80, 30),
-            Font = new Font("Segoe UI", 9F),
-            BackColor = _colorScheme.ButtonBackColor,
-            ForeColor = _colorScheme.PrimaryTextColor,
-            FlatStyle = FlatStyle.Flat,
-            Cursor = Cursors.Hand
-        };
-        _closeButton.FlatAppearance.BorderSize = 1;
-        _closeButton.FlatAppearance.BorderColor = _colorScheme.BorderColor;
-        _closeButton.Click += (s, e) => MinimizeToTray();
-        this.Controls.Add(_closeButton);
+        var version = Assembly.GetExecutingAssembly().GetName().Version;
+        _versionLabel.Text = version == null
+            ? "Version 2.0"
+            : $"Version {version.Major}.{version.Minor}";
     }
 
     /// <summary>
-    /// Initializes the system tray icon with a context menu for quick access to application functions.
-    /// Sets up menu items for showing settings, updating wallpaper, and exiting the application.
+    /// Initializes the system tray icon.
     /// </summary>
     private void InitializeTrayIcon()
     {
@@ -466,32 +238,32 @@ public partial class SettingsForm : Form
         };
 
         var contextMenu = new ContextMenuStrip();
-        
+
         var showSettingsItem = new ToolStripMenuItem("Settings")
         {
             Font = new Font(contextMenu.Font, FontStyle.Bold)
         };
         showSettingsItem.Click += (s, e) => ShowSettingsWindow();
         contextMenu.Items.Add(showSettingsItem);
-        
+
         contextMenu.Items.Add(new ToolStripSeparator());
-        
+
         var updateNowItem = new ToolStripMenuItem("Update Wallpaper Now");
         updateNowItem.Click += (s, e) => _ = UpdateWallpaperNow();
         contextMenu.Items.Add(updateNowItem);
-        
+
         contextMenu.Items.Add(new ToolStripSeparator());
-        
+
         var exitItem = new ToolStripMenuItem("Exit");
         exitItem.Click += (s, e) => ExitApplication();
         contextMenu.Items.Add(exitItem);
-        
+
         _notifyIcon.ContextMenuStrip = contextMenu;
         _notifyIcon.DoubleClick += (s, e) => ShowSettingsWindow();
     }
 
     /// <summary>
-    /// Shows the settings window by bringing it to the foreground and restoring it from the system tray.
+    /// Shows the settings window.
     /// </summary>
     private void ShowSettingsWindow()
     {
@@ -512,14 +284,13 @@ public partial class SettingsForm : Form
     /// <summary>
     /// Loads the application icon from embedded resources.
     /// </summary>
-    /// <returns>The application icon, or a system icon as fallback.</returns>
     private static Icon LoadEmbeddedIcon()
     {
         try
         {
             var assembly = Assembly.GetExecutingAssembly();
             var resourceName = "WorldMapWallpaper.Settings.Resources.AppIcon.ico";
-            
+
             using var stream = assembly.GetManifestResourceStream(resourceName);
             if (stream != null)
             {
@@ -528,22 +299,21 @@ public partial class SettingsForm : Form
         }
         catch
         {
-            // Fall back to system icon if embedded resource loading fails
+            // Fall back to system icon
         }
-        
+
         return SystemIcons.Application;
     }
 
     /// <summary>
-    /// Asynchronously updates the wallpaper immediately and displays notification balloons to inform the user of the progress and result.
+    /// Updates the wallpaper immediately.
     /// </summary>
-    /// <returns>A task representing the asynchronous operation.</returns>
     private async Task UpdateWallpaperNow()
     {
         try
         {
             _notifyIcon!.ShowBalloonTip(2000, "World Map Wallpaper", "Updating wallpaper...", ToolTipIcon.Info);
-            
+
             var success = TaskManager.RunTaskNow();
             if (success)
                 _notifyIcon.ShowBalloonTip(2000, "World Map Wallpaper", "Wallpaper updated successfully!", ToolTipIcon.Info);
@@ -557,7 +327,7 @@ public partial class SettingsForm : Form
     }
 
     /// <summary>
-    /// Exits the application completely by disposing of the tray icon and calling Application.Exit().
+    /// Exits the application.
     /// </summary>
     private void ExitApplication()
     {
@@ -566,10 +336,11 @@ public partial class SettingsForm : Form
     }
 
     /// <summary>
-    /// Loads the current settings from the application configuration and updates the form controls to reflect these values.
+    /// Loads settings into form controls.
     /// </summary>
     private void LoadSettings()
     {
+        // General tab
         _issCheckBox.Checked = Shared.Settings.ShowISS;
         _timeZonesCheckBox.Checked = Shared.Settings.ShowTimeZones;
         _politicalMapCheckBox.Checked = Shared.Settings.ShowPoliticalMap;
@@ -577,20 +348,17 @@ public partial class SettingsForm : Form
         var currentInterval = Shared.Settings.UpdateInterval;
         for (var i = 0; i < _updateIntervalCombo.Items.Count; i++)
         {
-            if (_updateIntervalCombo.Items[i] is ComboBoxItem item &&
-                item.Value.Equals(currentInterval))
+            if (_updateIntervalCombo.Items[i] is ComboBoxItem item && item.Value.Equals(currentInterval))
             {
                 _updateIntervalCombo.SelectedIndex = i;
                 break;
             }
         }
 
-        // Load resolution settings
         var currentResMode = Shared.Settings.ResolutionMode;
         for (var i = 0; i < _resolutionModeCombo.Items.Count; i++)
         {
-            if (_resolutionModeCombo.Items[i] is ComboBoxItem item &&
-                item.Value.Equals(currentResMode))
+            if (_resolutionModeCombo.Items[i] is ComboBoxItem item && item.Value.Equals(currentResMode))
             {
                 _resolutionModeCombo.SelectedIndex = i;
                 break;
@@ -599,12 +367,75 @@ public partial class SettingsForm : Form
 
         _customWidthTextBox.Text = Shared.Settings.CustomResolutionWidth.ToString();
         _customHeightTextBox.Text = Shared.Settings.CustomResolutionHeight.ToString();
-
         UpdateCustomResolutionState();
+
+        // Satellites tab
+        _satelliteTrackingCheckBox.Checked = Shared.Settings.SatelliteTrackingEnabled;
+        LoadSatelliteList();
+        _maxVisibleUpDown.Value = SatelliteConfigManager.Instance.MaxVisibleSatellites;
+        UpdateSatelliteUI();
     }
 
     /// <summary>
-    /// Saves the current form control values to the application settings and updates the task schedule if necessary.
+    /// Loads the satellite list from configuration.
+    /// </summary>
+    private void LoadSatelliteList()
+    {
+        _satelliteListBox.Items.Clear();
+
+        var satellites = SatelliteConfigManager.Instance.Satellites
+            .OrderBy(s => s.Priority)
+            .ToList();
+
+        foreach (var sat in satellites)
+        {
+            _satelliteListBox.Items.Add(new SatelliteListItem(sat));
+        }
+
+        UpdateSatelliteCountLabel();
+    }
+
+    /// <summary>
+    /// Updates the satellite count label.
+    /// </summary>
+    private void UpdateSatelliteCountLabel()
+    {
+        var total = SatelliteConfigManager.Instance.Satellites.Count;
+        var enabled = SatelliteConfigManager.Instance.Satellites.Count(s => s.Enabled);
+        _satelliteCountLabel.Text = $"({enabled} enabled / {total} total)";
+    }
+
+    /// <summary>
+    /// Updates the satellite UI button states.
+    /// </summary>
+    private void UpdateSatelliteUI()
+    {
+        var hasSelection = _satelliteListBox.SelectedItem != null;
+        var selectedIndex = _satelliteListBox.SelectedIndex;
+
+        _editSatelliteButton.Enabled = hasSelection;
+        _removeSatelliteButton.Enabled = hasSelection;
+        _moveUpButton.Enabled = hasSelection && selectedIndex > 0;
+        _moveDownButton.Enabled = hasSelection && selectedIndex < _satelliteListBox.Items.Count - 1;
+
+        var trackingEnabled = _satelliteTrackingCheckBox.Checked;
+        _satelliteListBox.Enabled = trackingEnabled;
+        _addSatelliteButton.Enabled = trackingEnabled;
+        _maxVisibleUpDown.Enabled = trackingEnabled;
+
+        if (!trackingEnabled)
+        {
+            _editSatelliteButton.Enabled = false;
+            _removeSatelliteButton.Enabled = false;
+            _moveUpButton.Enabled = false;
+            _moveDownButton.Enabled = false;
+        }
+
+        ApplyThemeToButtons();
+    }
+
+    /// <summary>
+    /// Saves current settings.
     /// </summary>
     private void SaveSettings()
     {
@@ -618,7 +449,6 @@ public partial class SettingsForm : Form
             TaskManager.UpdateTaskSchedule((UpdateInterval)item.Value);
         }
 
-        // Save resolution settings
         if (_resolutionModeCombo.SelectedItem is ComboBoxItem resItem)
         {
             Shared.Settings.ResolutionMode = (ResolutionMode)resItem.Value;
@@ -635,53 +465,19 @@ public partial class SettingsForm : Form
         }
     }
 
-    /// <summary>
-    /// Event handler that is triggered when any of the visual element checkboxes are changed.
-    /// Automatically saves the new settings.
-    /// </summary>
-    /// <param name="sender">The checkbox control that triggered the event.</param>
-    /// <param name="e">Event arguments containing information about the change.</param>
-    private void OnSettingChanged(object? sender, EventArgs e)
-    {
-        SaveSettings();
-    }
+    // Event handlers
+    private void OnSettingChanged(object? sender, EventArgs e) => SaveSettings();
 
-    /// <summary>
-    /// Event handler that is triggered when the update interval combo box selection changes.
-    /// Automatically saves the new settings and updates the task schedule.
-    /// </summary>
-    /// <param name="sender">The combo box control that triggered the event.</param>
-    /// <param name="e">Event arguments containing information about the selection change.</param>
-    private void OnUpdateIntervalChanged(object? sender, EventArgs e)
-    {
-        SaveSettings();
-    }
+    private void OnUpdateIntervalChanged(object? sender, EventArgs e) => SaveSettings();
 
-    /// <summary>
-    /// Event handler for resolution mode combo box changes.
-    /// </summary>
-    /// <param name="sender">The combo box control that triggered the event.</param>
-    /// <param name="e">Event arguments for the selection change.</param>
     private void OnResolutionModeChanged(object? sender, EventArgs e)
     {
         SaveSettings();
         UpdateCustomResolutionState();
     }
 
-    /// <summary>
-    /// Event handler for custom resolution text box changes.
-    /// </summary>
-    /// <param name="sender">The text box control that triggered the event.</param>
-    /// <param name="e">Event arguments for the text change.</param>
-    private void OnCustomResolutionChanged(object? sender, EventArgs e)
-    {
-        SaveSettings();
-    }
+    private void OnCustomResolutionChanged(object? sender, EventArgs e) => SaveSettings();
 
-    /// <summary>
-    /// Updates the enabled state of custom resolution inputs based on mode.
-    /// Custom resolution inputs are only enabled when resolution mode is not None.
-    /// </summary>
     private void UpdateCustomResolutionState()
     {
         var mode = ResolutionMode.None;
@@ -695,10 +491,6 @@ public partial class SettingsForm : Form
         _customHeightTextBox.Enabled = enableCustom;
     }
 
-    /// <summary>
-    /// Gets the detected screen resolution as a display string.
-    /// </summary>
-    /// <returns>A string showing the detected primary screen resolution.</returns>
     private static string GetDetectedResolutionText()
     {
         try
@@ -709,19 +501,96 @@ public partial class SettingsForm : Form
                 return $"Detected: {screen.Bounds.Width} x {screen.Bounds.Height}";
             }
         }
-        catch
-        {
-            // Ignore detection errors
-        }
+        catch { }
         return "Detected: Unable to detect";
     }
 
-    /// <summary>
-    /// Event handler for the preview/update button click. Temporarily disables the button, 
-    /// saves current settings, attempts to update the wallpaper, and provides user feedback.
-    /// </summary>
-    /// <param name="sender">The button control that was clicked.</param>
-    /// <param name="e">Event arguments for the click event.</param>
+    private void OnSatelliteTrackingChanged(object? sender, EventArgs e)
+    {
+        Shared.Settings.SatelliteTrackingEnabled = _satelliteTrackingCheckBox.Checked;
+        UpdateSatelliteUI();
+    }
+
+    private void OnSatelliteSelectionChanged(object? sender, EventArgs e) => UpdateSatelliteUI();
+
+    private void OnSatelliteDoubleClick(object? sender, EventArgs e) => OnEditSatelliteClick(sender, e);
+
+    private void OnAddSatelliteClick(object? sender, EventArgs e)
+    {
+        using var dialog = new AddSatelliteDialog();
+        if (dialog.ShowDialog(this) == DialogResult.OK)
+        {
+            LoadSatelliteList();
+        }
+    }
+
+    private void OnEditSatelliteClick(object? sender, EventArgs e)
+    {
+        if (_satelliteListBox.SelectedItem is SatelliteListItem item)
+        {
+            using var dialog = new SatelliteEditDialog(item.Config);
+            if (dialog.ShowDialog(this) == DialogResult.OK && dialog.WasModified)
+            {
+                LoadSatelliteList();
+            }
+        }
+    }
+
+    private void OnRemoveSatelliteClick(object? sender, EventArgs e)
+    {
+        if (_satelliteListBox.SelectedItem is SatelliteListItem item)
+        {
+            var result = MessageBox.Show(
+                $"Remove {item.Config.Name} from tracking?",
+                "Confirm Removal",
+                MessageBoxButtons.YesNo,
+                MessageBoxIcon.Question);
+
+            if (result == DialogResult.Yes)
+            {
+                SatelliteConfigManager.Instance.RemoveSatellite(item.Config.NoradId);
+                LoadSatelliteList();
+            }
+        }
+    }
+
+    private void OnMoveUpClick(object? sender, EventArgs e)
+    {
+        var index = _satelliteListBox.SelectedIndex;
+        if (index > 0)
+        {
+            ReorderSatellites(index, index - 1);
+        }
+    }
+
+    private void OnMoveDownClick(object? sender, EventArgs e)
+    {
+        var index = _satelliteListBox.SelectedIndex;
+        if (index < _satelliteListBox.Items.Count - 1)
+        {
+            ReorderSatellites(index, index + 1);
+        }
+    }
+
+    private void ReorderSatellites(int fromIndex, int toIndex)
+    {
+        var items = _satelliteListBox.Items.Cast<SatelliteListItem>().ToList();
+        var item = items[fromIndex];
+        items.RemoveAt(fromIndex);
+        items.Insert(toIndex, item);
+
+        var noradIds = items.Select(i => i.Config.NoradId);
+        SatelliteConfigManager.Instance.ReorderSatellites(noradIds);
+
+        LoadSatelliteList();
+        _satelliteListBox.SelectedIndex = toIndex;
+    }
+
+    private void OnMaxVisibleChanged(object? sender, EventArgs e)
+    {
+        SatelliteConfigManager.Instance.MaxVisibleSatellites = (int)_maxVisibleUpDown.Value;
+    }
+
     private async void OnPreviewClick(object? sender, EventArgs e)
     {
         _previewButton.Enabled = false;
@@ -730,7 +599,7 @@ public partial class SettingsForm : Form
         try
         {
             SaveSettings();
-            
+
             if (TaskManager.RunTaskNow())
             {
                 _previewButton.Text = "Updated!";
@@ -749,16 +618,10 @@ public partial class SettingsForm : Form
         }
     }
 
-    /// <summary>
-    /// Event handler for the reset button click. Prompts the user for confirmation 
-    /// before resetting all settings to their default values.
-    /// </summary>
-    /// <param name="sender">The button control that was clicked.</param>
-    /// <param name="e">Event arguments for the click event.</param>
     private void OnResetClick(object? sender, EventArgs e)
     {
         var result = MessageBox.Show(
-            "Are you sure you want to reset all settings to their default values?",
+            "Reset all settings to defaults?\nThis will also reset satellite configuration to ISS only.",
             "Reset Settings",
             MessageBoxButtons.YesNo,
             MessageBoxIcon.Question);
@@ -766,15 +629,11 @@ public partial class SettingsForm : Form
         if (result == DialogResult.Yes)
         {
             Shared.Settings.ResetToDefaults();
+            SatelliteConfigManager.Instance.ResetToDefaults();
             LoadSettings();
         }
     }
 
-
-    /// <summary>
-    /// Initializes and starts the wallpaper monitoring service to detect when the user changes 
-    /// to a different wallpaper provider.
-    /// </summary>
     private void StartWallpaperMonitoring()
     {
         _wallpaperMonitor = new WallpaperMonitor();
@@ -782,52 +641,33 @@ public partial class SettingsForm : Form
         _wallpaperMonitor.Start();
     }
 
-    /// <summary>
-    /// Event handler that is triggered when the system wallpaper changes. If the user has switched 
-    /// to a different wallpaper, disables the automatic update task and shows a notification.
-    /// </summary>
-    /// <param name="isOurWallpaper">True if the current wallpaper is from this application; false if the user switched to a different wallpaper.</param>
     private void OnWallpaperChanged(bool isOurWallpaper)
     {
         if (!isOurWallpaper)
         {
-            // User switched to a different wallpaper - disable our task
             TaskManager.EnableTask(false);
             Shared.Settings.IsActive = false;
-            
-            // Show notification instead of closing
+
             if (InvokeRequired)
-                Invoke(new Action(() => _notifyIcon?.ShowBalloonTip(3000, "World Map Wallpaper", "Automatic updates disabled - you switched to a different wallpaper", ToolTipIcon.Info)));
+                Invoke(new Action(() => _notifyIcon?.ShowBalloonTip(3000, "World Map Wallpaper",
+                    "Automatic updates disabled - you switched to a different wallpaper", ToolTipIcon.Info)));
             else
-                _notifyIcon?.ShowBalloonTip(3000, "World Map Wallpaper", "Automatic updates disabled - you switched to a different wallpaper", ToolTipIcon.Info);
+                _notifyIcon?.ShowBalloonTip(3000, "World Map Wallpaper",
+                    "Automatic updates disabled - you switched to a different wallpaper", ToolTipIcon.Info);
         }
     }
 
-    /// <summary>
-    /// Overrides the base SetVisibleCore method to prevent the form from becoming visible 
-    /// when it should be minimized to the system tray.
-    /// </summary>
-    /// <param name="value">The visibility state to set.</param>
     protected override void SetVisibleCore(bool value)
     {
-        // Prevent the form from becoming visible at design time or when minimized to tray
         base.SetVisibleCore(!_minimizeToTray && value);
     }
 
-    /// <summary>
-    /// Overrides the form closing behavior to minimize to the system tray instead of actually closing 
-    /// when the user clicks the close button.
-    /// </summary>
-    /// <param name="e">Event arguments that can be used to cancel the closing operation.</param>
     protected override void OnFormClosing(FormClosingEventArgs e)
     {
-        // Minimize to tray instead of closing when user clicks X
         if (e.CloseReason == CloseReason.UserClosing)
         {
             e.Cancel = true;
-            this.WindowState = FormWindowState.Minimized;
-            this.ShowInTaskbar = false;
-            this.Visible = false;
+            MinimizeToTray();
         }
         else
         {
@@ -835,11 +675,6 @@ public partial class SettingsForm : Form
         }
     }
 
-    /// <summary>
-    /// Overrides the form closed event to properly dispose of resources including 
-    /// the wallpaper monitor and system tray icon.
-    /// </summary>
-    /// <param name="e">Event arguments containing information about how the form was closed.</param>
     protected override void OnFormClosed(FormClosedEventArgs e)
     {
         _wallpaperMonitor?.Stop();
@@ -848,10 +683,6 @@ public partial class SettingsForm : Form
         base.OnFormClosed(e);
     }
 
-    /// <summary>
-    /// Gets the current task status as a user-friendly string.
-    /// </summary>
-    /// <returns>A string describing the current task status.</returns>
     private static string GetTaskStatusText()
     {
         if (!TaskManager.TaskExists())
@@ -865,38 +696,40 @@ public partial class SettingsForm : Form
         {
             var (state, nextRun) = taskInfo.Value;
             var nextRunText = nextRun?.ToString("MMM d, h:mm tt") ?? "Not scheduled";
-            
-            // Get trigger count for additional info
             var triggers = TaskManager.GetTriggerInfo();
-            var triggerCount = triggers.Count;
-            
-            return $"Task active with {triggerCount} triggers - Next: {nextRunText}";
+            return $"Task active with {triggers.Count} triggers - Next: {nextRunText}";
         }
 
         return "Task status unknown";
     }
 
     /// <summary>
-    /// Helper class for ComboBox items that associates a display string with an underlying value.
+    /// Helper class for ComboBox items.
     /// </summary>
-    /// <param name="display">The text to display in the combo box.</param>
-    /// <param name="value">The underlying value associated with this item.</param>
     private class ComboBoxItem(string display, object value)
     {
-        /// <summary>
-        /// Gets the display text for this combo box item.
-        /// </summary>
         public string Display { get; } = display;
-        
-        /// <summary>
-        /// Gets the underlying value associated with this combo box item.
-        /// </summary>
         public object Value { get; } = value;
-
-        /// <summary>
-        /// Returns the display string for this combo box item.
-        /// </summary>
-        /// <returns>The display text.</returns>
         public override string ToString() => Display;
+    }
+
+    /// <summary>
+    /// Helper class for satellite list items.
+    /// </summary>
+    private class SatelliteListItem
+    {
+        public SatelliteConfig Config { get; }
+
+        public SatelliteListItem(SatelliteConfig config)
+        {
+            Config = config;
+        }
+
+        public override string ToString()
+        {
+            var status = Config.Enabled ? "" : " [disabled]";
+            var lagrange = Config.IsLagrangePoint ? " [L-point]" : "";
+            return $"{Config.Name} (#{Config.NoradId}){status}{lagrange}";
+        }
     }
 }

--- a/Settings/SettingsForm.cs
+++ b/Settings/SettingsForm.cs
@@ -39,6 +39,7 @@ public partial class SettingsForm : Form
     public SettingsForm(bool minimizeToTray = false)
     {
         _colorScheme = ThemeManager.GetCurrentColorScheme();
+        _minimizeToTray = minimizeToTray;
 
         InitializeComponent();
         WireEvents();
@@ -344,6 +345,8 @@ public partial class SettingsForm : Form
         _issCheckBox.Checked = Shared.Settings.ShowISS;
         _timeZonesCheckBox.Checked = Shared.Settings.ShowTimeZones;
         _politicalMapCheckBox.Checked = Shared.Settings.ShowPoliticalMap;
+        _taskStatusLabel.Text = GetTaskStatusText();
+        _detectedResolutionLabel.Text = GetDetectedResolutionText();
 
         var currentInterval = Shared.Settings.UpdateInterval;
         for (var i = 0; i < _updateIntervalCombo.Items.Count; i++)
@@ -463,6 +466,11 @@ public partial class SettingsForm : Form
         {
             Shared.Settings.CustomResolutionHeight = Math.Max(0, height);
         }
+
+        _taskStatusLabel.Text = GetTaskStatusText();
+        _detectedResolutionLabel.Text = GetDetectedResolutionText();
+        ApplyThemeToLabel(_taskStatusLabel);
+        ApplyThemeToLabel(_detectedResolutionLabel);
     }
 
     // Event handlers
@@ -655,11 +663,6 @@ public partial class SettingsForm : Form
                 _notifyIcon?.ShowBalloonTip(3000, "World Map Wallpaper",
                     "Automatic updates disabled - you switched to a different wallpaper", ToolTipIcon.Info);
         }
-    }
-
-    protected override void SetVisibleCore(bool value)
-    {
-        base.SetVisibleCore(!_minimizeToTray && value);
     }
 
     protected override void OnFormClosing(FormClosingEventArgs e)

--- a/Settings/WorldMapWallpaper.Settings.csproj
+++ b/Settings/WorldMapWallpaper.Settings.csproj
@@ -6,6 +6,9 @@
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <UseWindowsForms>true</UseWindowsForms>
+    <Version>2.0.0</Version>
+    <AssemblyVersion>2.0.0.0</AssemblyVersion>
+    <FileVersion>2.0.0.0</FileVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Shared/Models/SatelliteConfig.cs
+++ b/Shared/Models/SatelliteConfig.cs
@@ -1,0 +1,168 @@
+using System.Text.Json.Serialization;
+
+namespace WorldMapWallpaper.Shared.Models;
+
+/// <summary>
+/// Represents the configuration for a tracked satellite.
+/// </summary>
+public class SatelliteConfig
+{
+    /// <summary>
+    /// Gets or sets the display name of the satellite.
+    /// </summary>
+    [JsonPropertyName("name")]
+    public string Name { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the NORAD catalog number for the satellite.
+    /// </summary>
+    [JsonPropertyName("noradId")]
+    public int NoradId { get; set; }
+
+    /// <summary>
+    /// Gets or sets whether this satellite is enabled for display.
+    /// </summary>
+    [JsonPropertyName("enabled")]
+    public bool Enabled { get; set; } = true;
+
+    /// <summary>
+    /// Gets or sets the path to a custom icon file.
+    /// Null or empty means use the default icon for the category.
+    /// </summary>
+    [JsonPropertyName("iconPath")]
+    public string? IconPath { get; set; }
+
+    /// <summary>
+    /// Gets or sets the orbit trail color in hex format (e.g., "#FF6B35").
+    /// Null means auto-assign from the default palette.
+    /// </summary>
+    [JsonPropertyName("color")]
+    public string? Color { get; set; }
+
+    /// <summary>
+    /// Gets or sets whether to show the orbital path for this satellite.
+    /// </summary>
+    [JsonPropertyName("showOrbit")]
+    public bool ShowOrbit { get; set; } = true;
+
+    /// <summary>
+    /// Gets or sets the display priority (lower = higher priority).
+    /// Used when more satellites are enabled than the visibility limit.
+    /// </summary>
+    [JsonPropertyName("priority")]
+    public int Priority { get; set; } = 100;
+
+    /// <summary>
+    /// Gets or sets the satellite category for icon selection.
+    /// </summary>
+    [JsonPropertyName("category")]
+    public SatelliteCategory Category { get; set; } = SatelliteCategory.Default;
+
+    /// <summary>
+    /// Gets or sets whether this satellite is at a Lagrange point.
+    /// If true, position display will not be accurate.
+    /// </summary>
+    [JsonPropertyName("isLagrangePoint")]
+    public bool IsLagrangePoint { get; set; }
+}
+
+/// <summary>
+/// Categories of satellites for icon assignment.
+/// </summary>
+public enum SatelliteCategory
+{
+    /// <summary>Default generic satellite icon.</summary>
+    Default,
+
+    /// <summary>Space stations (ISS, Tiangong).</summary>
+    SpaceStation,
+
+    /// <summary>Telescopes (Hubble).</summary>
+    Telescope,
+
+    /// <summary>Weather satellites (GOES, NOAA).</summary>
+    Weather,
+
+    /// <summary>Earth observation satellites (Landsat, Sentinel).</summary>
+    EarthObservation,
+
+    /// <summary>Science satellites (Terra, Aqua).</summary>
+    Science,
+
+    /// <summary>Navigation satellites (GPS).</summary>
+    Navigation
+}
+
+/// <summary>
+/// Root configuration object for satellite tracking.
+/// </summary>
+public class SatelliteConfigRoot
+{
+    /// <summary>
+    /// Configuration file version for migration purposes.
+    /// </summary>
+    [JsonPropertyName("version")]
+    public int Version { get; set; } = 1;
+
+    /// <summary>
+    /// Maximum number of satellites to display at once (1-15).
+    /// </summary>
+    [JsonPropertyName("maxVisibleSatellites")]
+    public int MaxVisibleSatellites { get; set; } = 5;
+
+    /// <summary>
+    /// Number of orbit trail points to render (before + after current position).
+    /// </summary>
+    [JsonPropertyName("defaultOrbitPoints")]
+    public int DefaultOrbitPoints { get; set; } = 50;
+
+    /// <summary>
+    /// Visibility mode for satellite display.
+    /// </summary>
+    [JsonPropertyName("visibilityMode")]
+    public SatelliteVisibilityMode VisibilityMode { get; set; } = SatelliteVisibilityMode.All;
+
+    /// <summary>
+    /// List of configured satellites.
+    /// </summary>
+    [JsonPropertyName("satellites")]
+    public List<SatelliteConfig> Satellites { get; set; } = new();
+}
+
+/// <summary>
+/// Visibility modes for satellite display.
+/// </summary>
+public enum SatelliteVisibilityMode
+{
+    /// <summary>Show all enabled satellites up to the limit.</summary>
+    All,
+
+    /// <summary>Only show satellites currently in sunlight.</summary>
+    DaylightOnly
+}
+
+/// <summary>
+/// Extension methods for SatelliteCategory enum.
+/// </summary>
+public static class SatelliteCategoryExtensions
+{
+    /// <summary>
+    /// Gets a user-friendly display string for the satellite category.
+    /// </summary>
+    /// <param name="category">The satellite category.</param>
+    /// <returns>A display string.</returns>
+    public static string ToDisplayString(this SatelliteCategory category)
+    {
+        return category switch
+        {
+            SatelliteCategory.Default => "Other",
+            SatelliteCategory.SpaceStation => "Space Station",
+            SatelliteCategory.Telescope => "Telescope",
+            SatelliteCategory.Weather => "Weather",
+            SatelliteCategory.EarthObservation => "Earth Observation",
+            SatelliteCategory.Science => "Science",
+            SatelliteCategory.Navigation => "Navigation",
+            _ => category.ToString()
+        };
+    }
+}

--- a/Shared/Models/SatellitePreset.cs
+++ b/Shared/Models/SatellitePreset.cs
@@ -1,0 +1,295 @@
+namespace WorldMapWallpaper.Shared.Models;
+
+/// <summary>
+/// Represents a preset satellite that users can easily add.
+/// </summary>
+public class SatellitePreset
+{
+    /// <summary>
+    /// Gets the display name of the satellite.
+    /// </summary>
+    public string Name { get; }
+
+    /// <summary>
+    /// Gets the NORAD catalog number.
+    /// </summary>
+    public int NoradId { get; }
+
+    /// <summary>
+    /// Gets the satellite category.
+    /// </summary>
+    public SatelliteCategory Category { get; }
+
+    /// <summary>
+    /// Gets the orbit type description (LEO, MEO, GEO).
+    /// </summary>
+    public string OrbitType { get; }
+
+    /// <summary>
+    /// Gets the suggested orbit trail color.
+    /// </summary>
+    public string SuggestedColor { get; }
+
+    /// <summary>
+    /// Gets whether this satellite is at a Lagrange point.
+    /// </summary>
+    public bool IsLagrangePoint { get; }
+
+    /// <summary>
+    /// Gets the Lagrange point location (L1, L2, etc.) if applicable.
+    /// </summary>
+    public string? LagrangePointLocation { get; }
+
+    private SatellitePreset(
+        string name,
+        int noradId,
+        SatelliteCategory category,
+        string orbitType,
+        string suggestedColor,
+        bool isLagrangePoint = false,
+        string? lagrangePointLocation = null)
+    {
+        Name = name;
+        NoradId = noradId;
+        Category = category;
+        OrbitType = orbitType;
+        SuggestedColor = suggestedColor;
+        IsLagrangePoint = isLagrangePoint;
+        LagrangePointLocation = lagrangePointLocation;
+    }
+
+    /// <summary>
+    /// Converts this preset to a SatelliteConfig for use in tracking.
+    /// </summary>
+    /// <param name="priority">The priority to assign.</param>
+    /// <returns>A new SatelliteConfig based on this preset.</returns>
+    public SatelliteConfig ToConfig(int priority)
+    {
+        return new SatelliteConfig
+        {
+            Name = Name,
+            NoradId = NoradId,
+            Enabled = true,
+            IconPath = null,
+            Color = SuggestedColor,
+            ShowOrbit = true,
+            Priority = priority,
+            Category = Category,
+            IsLagrangePoint = IsLagrangePoint
+        };
+    }
+
+    /// <summary>
+    /// Gets all available preset satellites.
+    /// </summary>
+    public static IReadOnlyList<SatellitePreset> All => _presets;
+
+    /// <summary>
+    /// Gets preset satellites filtered by category.
+    /// </summary>
+    /// <param name="category">The category to filter by.</param>
+    /// <returns>Presets matching the category.</returns>
+    public static IEnumerable<SatellitePreset> ByCategory(SatelliteCategory category)
+    {
+        return _presets.Where(p => p.Category == category);
+    }
+
+    /// <summary>
+    /// Gets Earth-orbiting preset satellites (excludes Lagrange point satellites).
+    /// </summary>
+    public static IEnumerable<SatellitePreset> EarthOrbiting =>
+        _presets.Where(p => !p.IsLagrangePoint);
+
+    /// <summary>
+    /// Gets Lagrange point satellites (for warning purposes).
+    /// </summary>
+    public static IEnumerable<SatellitePreset> LagrangePointSatellites =>
+        _presets.Where(p => p.IsLagrangePoint);
+
+    /// <summary>
+    /// Finds a preset by NORAD ID.
+    /// </summary>
+    /// <param name="noradId">The NORAD catalog number.</param>
+    /// <returns>The preset if found, null otherwise.</returns>
+    public static SatellitePreset? FindByNoradId(int noradId)
+    {
+        return _presets.FirstOrDefault(p => p.NoradId == noradId);
+    }
+
+    // Default color palette for orbit trails
+    private static readonly string[] _defaultColors =
+    {
+        "#FF6B35",  // Orange (ISS default)
+        "#4ECDC4",  // Teal
+        "#FFE66D",  // Yellow
+        "#95E1D3",  // Mint
+        "#F38181",  // Coral
+        "#AA96DA",  // Lavender
+        "#81B214",  // Green
+        "#2C786C",  // Dark Teal
+        "#F9ED69",  // Light Yellow
+        "#B83B5E",  // Magenta
+    };
+
+    /// <summary>
+    /// Gets the default color palette for orbit trails.
+    /// </summary>
+    public static IReadOnlyList<string> DefaultColorPalette => _defaultColors;
+
+    /// <summary>
+    /// Gets a suggested color for a new satellite based on index.
+    /// </summary>
+    /// <param name="index">The satellite index.</param>
+    /// <returns>A hex color string.</returns>
+    public static string GetSuggestedColor(int index)
+    {
+        return _defaultColors[index % _defaultColors.Length];
+    }
+
+    // Preset satellite definitions
+    private static readonly List<SatellitePreset> _presets = new()
+    {
+        // Space Stations
+        new SatellitePreset(
+            "International Space Station",
+            25544,
+            SatelliteCategory.SpaceStation,
+            "LEO",
+            "#FF6B35"),
+
+        new SatellitePreset(
+            "Tiangong Space Station",
+            48274,
+            SatelliteCategory.SpaceStation,
+            "LEO",
+            "#FFE66D"),
+
+        // Telescopes (Earth-orbiting)
+        new SatellitePreset(
+            "Hubble Space Telescope",
+            20580,
+            SatelliteCategory.Telescope,
+            "LEO",
+            "#4ECDC4"),
+
+        // Weather Satellites
+        new SatellitePreset(
+            "GOES-18",
+            51850,
+            SatelliteCategory.Weather,
+            "GEO",
+            "#95E1D3"),
+
+        new SatellitePreset(
+            "NOAA-20",
+            43013,
+            SatelliteCategory.Weather,
+            "LEO",
+            "#F38181"),
+
+        new SatellitePreset(
+            "NOAA-19",
+            33591,
+            SatelliteCategory.Weather,
+            "LEO",
+            "#AA96DA"),
+
+        new SatellitePreset(
+            "NOAA-18",
+            28654,
+            SatelliteCategory.Weather,
+            "LEO",
+            "#81B214"),
+
+        // Earth Observation
+        new SatellitePreset(
+            "Landsat 9",
+            49260,
+            SatelliteCategory.EarthObservation,
+            "LEO",
+            "#2C786C"),
+
+        new SatellitePreset(
+            "Landsat 8",
+            39084,
+            SatelliteCategory.EarthObservation,
+            "LEO",
+            "#F9ED69"),
+
+        new SatellitePreset(
+            "Sentinel-2A",
+            40697,
+            SatelliteCategory.EarthObservation,
+            "LEO",
+            "#B83B5E"),
+
+        // Science Satellites
+        new SatellitePreset(
+            "Terra",
+            25994,
+            SatelliteCategory.Science,
+            "LEO",
+            "#4ECDC4"),
+
+        new SatellitePreset(
+            "Aqua",
+            27424,
+            SatelliteCategory.Science,
+            "LEO",
+            "#95E1D3"),
+
+        // Navigation
+        new SatellitePreset(
+            "GPS IIF-12",
+            41019,
+            SatelliteCategory.Navigation,
+            "MEO",
+            "#FF6B35"),
+
+        // Lagrange Point Satellites (with warnings)
+        new SatellitePreset(
+            "James Webb Space Telescope",
+            50463,
+            SatelliteCategory.Telescope,
+            "L2",
+            "#AA96DA",
+            isLagrangePoint: true,
+            lagrangePointLocation: "L2"),
+
+        new SatellitePreset(
+            "DSCOVR",
+            43435,
+            SatelliteCategory.Science,
+            "L1",
+            "#81B214",
+            isLagrangePoint: true,
+            lagrangePointLocation: "L1"),
+
+        new SatellitePreset(
+            "Gaia",
+            39479,
+            SatelliteCategory.Telescope,
+            "L2",
+            "#F38181",
+            isLagrangePoint: true,
+            lagrangePointLocation: "L2"),
+
+        new SatellitePreset(
+            "SOHO",
+            28928,
+            SatelliteCategory.Science,
+            "L1",
+            "#FFE66D",
+            isLagrangePoint: true,
+            lagrangePointLocation: "L1"),
+
+        new SatellitePreset(
+            "Euclid",
+            52195,
+            SatelliteCategory.Telescope,
+            "L2",
+            "#2C786C",
+            isLagrangePoint: true,
+            lagrangePointLocation: "L2"),
+    };
+}

--- a/Shared/Services/BatchTleService.cs
+++ b/Shared/Services/BatchTleService.cs
@@ -150,12 +150,11 @@ public class BatchTleService
             _logAction?.Invoke($"Trying batch TLE fetch: {url}");
 
             var response = await _httpClient.GetStringAsync(url, cts.Token);
+            var parsedTles = ParseBatchTleResponse(response);
 
-            // Parse all TLEs from response
             foreach (var noradId in noradIds)
             {
-                var tle = TleData.ExtractSatelliteTle(response, noradId);
-                if (tle != null)
+                if (parsedTles.TryGetValue(noradId, out var tle))
                 {
                     results[noradId] = tle;
                 }
@@ -170,6 +169,34 @@ public class BatchTleService
         catch (Exception ex)
         {
             _logAction?.Invoke($"Batch TLE fetch failed: {ex.Message}");
+        }
+
+        return results;
+    }
+
+    /// <summary>
+    /// Parses a multi-satellite TLE response once into a lookup keyed by NORAD ID.
+    /// </summary>
+    private static Dictionary<int, TleData> ParseBatchTleResponse(string response)
+    {
+        var results = new Dictionary<int, TleData>();
+        var lines = response.Split(new[] { '\r', '\n' }, StringSplitOptions.RemoveEmptyEntries);
+
+        for (var i = 0; i + 2 < lines.Length; i += 3)
+        {
+            var line1 = lines[i + 1].Trim();
+            if (!line1.StartsWith("1 ") || line1.Length < 7)
+                continue;
+
+            if (!int.TryParse(line1.Substring(2, 5).Trim(), out var noradId))
+                continue;
+
+            var tleBlock = string.Join(Environment.NewLine, lines[i].Trim(), line1, lines[i + 2].Trim());
+            var tle = TleData.ParseFromText(tleBlock);
+            if (tle != null)
+            {
+                results[noradId] = tle;
+            }
         }
 
         return results;

--- a/Shared/Services/BatchTleService.cs
+++ b/Shared/Services/BatchTleService.cs
@@ -1,0 +1,476 @@
+using System.Collections.Concurrent;
+using System.Text.Json;
+using WorldMapWallpaper.Shared.Models;
+
+namespace WorldMapWallpaper.Shared.Services;
+
+/// <summary>
+/// Service for fetching TLE data for multiple satellites with batching, timeouts, and caching.
+/// </summary>
+public class BatchTleService
+{
+    private static readonly HttpClient _httpClient = new()
+    {
+        Timeout = TimeSpan.FromSeconds(10) // Overall client timeout
+    };
+
+    /// <summary>
+    /// Maximum number of satellites that can be fetched at once.
+    /// </summary>
+    public const int MaxSatellites = 50;
+
+    /// <summary>
+    /// Timeout per individual satellite request in seconds.
+    /// </summary>
+    public const int RequestTimeoutSeconds = 5;
+
+    /// <summary>
+    /// CelesTrak API URL template for single satellite.
+    /// </summary>
+    private const string CelesTrakSingleUrl = "https://celestrak.org/NORAD/elements/gp.php?CATNR={0}&FORMAT=TLE";
+
+    /// <summary>
+    /// CelesTrak API URL template for multiple satellites (comma-separated).
+    /// </summary>
+    private const string CelesTrakBatchUrl = "https://celestrak.org/NORAD/elements/gp.php?CATNR={0}&FORMAT=TLE";
+
+    /// <summary>
+    /// Cache directory for TLE data.
+    /// </summary>
+    private static readonly string CacheDirectory = Path.Combine(
+        Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData),
+        "WorldMapWallpaper", "tle_cache"
+    );
+
+    /// <summary>
+    /// Default cache expiration in hours (7 days).
+    /// </summary>
+    public const int DefaultCacheExpirationHours = 168;
+
+    /// <summary>
+    /// Maximum age for stale data in days (30 days).
+    /// </summary>
+    public const int StaleDataMaxAgeDays = 30;
+
+    private readonly Action<string>? _logAction;
+
+    /// <summary>
+    /// Initializes a new instance of the BatchTleService class.
+    /// </summary>
+    /// <param name="logAction">Optional logging action.</param>
+    public BatchTleService(Action<string>? logAction = null)
+    {
+        _logAction = logAction;
+        EnsureCacheDirectoryExists();
+    }
+
+    /// <summary>
+    /// Fetches TLE data for multiple satellites.
+    /// Tries batch request first, then falls back to parallel individual requests.
+    /// Uses cache as fallback when network requests fail.
+    /// </summary>
+    /// <param name="noradIds">The NORAD IDs to fetch.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>Dictionary mapping NORAD ID to TLE data (only successful fetches included).</returns>
+    public async Task<Dictionary<int, TleData>> FetchMultipleTleAsync(
+        IEnumerable<int> noradIds,
+        CancellationToken cancellationToken = default)
+    {
+        var idList = noradIds.Take(MaxSatellites).ToList();
+
+        if (idList.Count == 0)
+            return new Dictionary<int, TleData>();
+
+        _logAction?.Invoke($"Fetching TLE data for {idList.Count} satellite(s)...");
+
+        // Try batch request first
+        var results = await TryBatchFetchAsync(idList, cancellationToken);
+
+        // Check which ones are missing
+        var missing = idList.Where(id => !results.ContainsKey(id)).ToList();
+
+        if (missing.Count > 0)
+        {
+            _logAction?.Invoke($"Batch fetch incomplete, trying individual requests for {missing.Count} satellite(s)...");
+
+            // Try individual parallel requests for missing satellites
+            var individualResults = await FetchIndividualParallelAsync(missing, cancellationToken);
+
+            foreach (var kvp in individualResults)
+            {
+                results[kvp.Key] = kvp.Value;
+            }
+        }
+
+        // For any still missing, try cache
+        var stillMissing = idList.Where(id => !results.ContainsKey(id)).ToList();
+        if (stillMissing.Count > 0)
+        {
+            _logAction?.Invoke($"Using cache fallback for {stillMissing.Count} satellite(s)...");
+
+            foreach (var noradId in stillMissing)
+            {
+                var cached = LoadFromCache(noradId, maxAgeHours: StaleDataMaxAgeDays * 24);
+                if (cached != null)
+                {
+                    results[noradId] = cached;
+                    _logAction?.Invoke($"  Loaded {cached.SatelliteName} from cache");
+                }
+            }
+        }
+
+        // Cache all successful results
+        foreach (var kvp in results)
+        {
+            SaveToCache(kvp.Key, kvp.Value);
+        }
+
+        _logAction?.Invoke($"TLE fetch complete: {results.Count}/{idList.Count} successful");
+        return results;
+    }
+
+    /// <summary>
+    /// Attempts to fetch TLE data using batch API request.
+    /// </summary>
+    private async Task<Dictionary<int, TleData>> TryBatchFetchAsync(
+        List<int> noradIds,
+        CancellationToken cancellationToken)
+    {
+        var results = new Dictionary<int, TleData>();
+
+        try
+        {
+            using var cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+            cts.CancelAfter(TimeSpan.FromSeconds(RequestTimeoutSeconds));
+
+            // Build batch URL with comma-separated NORAD IDs
+            var idsString = string.Join(",", noradIds);
+            var url = string.Format(CelesTrakBatchUrl, idsString);
+
+            _logAction?.Invoke($"Trying batch TLE fetch: {url}");
+
+            var response = await _httpClient.GetStringAsync(url, cts.Token);
+
+            // Parse all TLEs from response
+            foreach (var noradId in noradIds)
+            {
+                var tle = TleData.ExtractSatelliteTle(response, noradId);
+                if (tle != null)
+                {
+                    results[noradId] = tle;
+                }
+            }
+
+            _logAction?.Invoke($"Batch fetch returned {results.Count} TLE(s)");
+        }
+        catch (OperationCanceledException)
+        {
+            _logAction?.Invoke("Batch TLE fetch timed out");
+        }
+        catch (Exception ex)
+        {
+            _logAction?.Invoke($"Batch TLE fetch failed: {ex.Message}");
+        }
+
+        return results;
+    }
+
+    /// <summary>
+    /// Fetches TLE data for individual satellites in parallel.
+    /// </summary>
+    private async Task<Dictionary<int, TleData>> FetchIndividualParallelAsync(
+        List<int> noradIds,
+        CancellationToken cancellationToken)
+    {
+        var results = new ConcurrentDictionary<int, TleData>();
+
+        var tasks = noradIds.Select(async noradId =>
+        {
+            try
+            {
+                using var cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+                cts.CancelAfter(TimeSpan.FromSeconds(RequestTimeoutSeconds));
+
+                var url = string.Format(CelesTrakSingleUrl, noradId);
+                var response = await _httpClient.GetStringAsync(url, cts.Token);
+
+                var tle = TleData.ParseFromText(response);
+                if (tle != null && tle.CatalogNumber == noradId)
+                {
+                    results.TryAdd(noradId, tle);
+                    _logAction?.Invoke($"  Fetched TLE for {tle.SatelliteName} (#{noradId})");
+                }
+            }
+            catch (OperationCanceledException)
+            {
+                _logAction?.Invoke($"  Timeout fetching TLE for #{noradId}");
+            }
+            catch (Exception ex)
+            {
+                _logAction?.Invoke($"  Failed to fetch TLE for #{noradId}: {ex.Message}");
+            }
+        });
+
+        await Task.WhenAll(tasks);
+        return results.ToDictionary(kv => kv.Key, kv => kv.Value);
+    }
+
+    /// <summary>
+    /// Fetches TLE data for a single satellite.
+    /// </summary>
+    /// <param name="noradId">The NORAD catalog number.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>TLE data or null if fetch fails.</returns>
+    public async Task<TleData?> FetchSingleTleAsync(int noradId, CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            using var cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+            cts.CancelAfter(TimeSpan.FromSeconds(RequestTimeoutSeconds));
+
+            var url = string.Format(CelesTrakSingleUrl, noradId);
+            var response = await _httpClient.GetStringAsync(url, cts.Token);
+
+            var tle = TleData.ParseFromText(response);
+            if (tle != null && tle.CatalogNumber == noradId)
+            {
+                SaveToCache(noradId, tle);
+                return tle;
+            }
+        }
+        catch (OperationCanceledException)
+        {
+            _logAction?.Invoke($"Timeout fetching TLE for #{noradId}");
+        }
+        catch (Exception ex)
+        {
+            _logAction?.Invoke($"Failed to fetch TLE for #{noradId}: {ex.Message}");
+        }
+
+        // Try cache as fallback
+        return LoadFromCache(noradId, maxAgeHours: StaleDataMaxAgeDays * 24);
+    }
+
+    /// <summary>
+    /// Gets TLE data for configured satellites from cache or network.
+    /// </summary>
+    /// <param name="satellites">The satellite configurations.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>Dictionary mapping NORAD ID to TLE data.</returns>
+    public async Task<Dictionary<int, TleData>> GetTleForSatellitesAsync(
+        IEnumerable<SatelliteConfig> satellites,
+        CancellationToken cancellationToken = default)
+    {
+        var enabledIds = satellites
+            .Where(s => s.Enabled)
+            .Select(s => s.NoradId)
+            .ToList();
+
+        return await FetchMultipleTleAsync(enabledIds, cancellationToken);
+    }
+
+    /// <summary>
+    /// Saves TLE data to cache.
+    /// </summary>
+    private void SaveToCache(int noradId, TleData tleData)
+    {
+        try
+        {
+            var cacheFile = GetCacheFilePath(noradId);
+            var cacheEntry = new TleCacheEntry
+            {
+                TleData = tleData,
+                CachedAt = DateTime.UtcNow
+            };
+
+            var json = JsonSerializer.Serialize(cacheEntry, new JsonSerializerOptions { WriteIndented = true });
+            File.WriteAllText(cacheFile, json);
+        }
+        catch
+        {
+            // Silently fail cache write
+        }
+    }
+
+    /// <summary>
+    /// Loads TLE data from cache.
+    /// </summary>
+    private TleData? LoadFromCache(int noradId, double maxAgeHours = DefaultCacheExpirationHours)
+    {
+        try
+        {
+            var cacheFile = GetCacheFilePath(noradId);
+            if (!File.Exists(cacheFile))
+                return null;
+
+            var json = File.ReadAllText(cacheFile);
+            var cacheEntry = JsonSerializer.Deserialize<TleCacheEntry>(json);
+
+            if (cacheEntry?.TleData == null)
+                return null;
+
+            var age = DateTime.UtcNow - cacheEntry.CachedAt;
+            if (age.TotalHours > maxAgeHours)
+                return null;
+
+            return cacheEntry.TleData;
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
+    /// <summary>
+    /// Gets cache information for all cached satellites.
+    /// </summary>
+    /// <returns>List of cache info entries.</returns>
+    public List<SatelliteCacheInfo> GetCacheInfo()
+    {
+        var result = new List<SatelliteCacheInfo>();
+
+        try
+        {
+            if (!Directory.Exists(CacheDirectory))
+                return result;
+
+            foreach (var file in Directory.GetFiles(CacheDirectory, "*.json"))
+            {
+                try
+                {
+                    var json = File.ReadAllText(file);
+                    var cacheEntry = JsonSerializer.Deserialize<TleCacheEntry>(json);
+
+                    if (cacheEntry?.TleData != null)
+                    {
+                        result.Add(new SatelliteCacheInfo
+                        {
+                            NoradId = cacheEntry.TleData.CatalogNumber,
+                            SatelliteName = cacheEntry.TleData.SatelliteName,
+                            CachedAt = cacheEntry.CachedAt,
+                            Age = DateTime.UtcNow - cacheEntry.CachedAt,
+                            EpochDate = cacheEntry.TleData.EpochDate
+                        });
+                    }
+                }
+                catch
+                {
+                    // Skip invalid cache files
+                }
+            }
+        }
+        catch
+        {
+            // Return empty list on error
+        }
+
+        return result.OrderBy(c => c.SatelliteName).ToList();
+    }
+
+    /// <summary>
+    /// Clears all cached TLE data.
+    /// </summary>
+    public void ClearCache()
+    {
+        try
+        {
+            if (Directory.Exists(CacheDirectory))
+            {
+                foreach (var file in Directory.GetFiles(CacheDirectory, "*.json"))
+                {
+                    File.Delete(file);
+                }
+                _logAction?.Invoke("TLE cache cleared");
+            }
+        }
+        catch (Exception ex)
+        {
+            _logAction?.Invoke($"Failed to clear TLE cache: {ex.Message}");
+        }
+    }
+
+    /// <summary>
+    /// Clears cached TLE data for a specific satellite.
+    /// </summary>
+    /// <param name="noradId">The NORAD catalog number.</param>
+    public void ClearCacheFor(int noradId)
+    {
+        try
+        {
+            var cacheFile = GetCacheFilePath(noradId);
+            if (File.Exists(cacheFile))
+            {
+                File.Delete(cacheFile);
+            }
+        }
+        catch
+        {
+            // Silently fail
+        }
+    }
+
+    /// <summary>
+    /// Forces a refresh of TLE data for all configured satellites.
+    /// </summary>
+    /// <param name="satellites">The satellite configurations.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>Dictionary mapping NORAD ID to TLE data.</returns>
+    public async Task<Dictionary<int, TleData>> RefreshAllTleAsync(
+        IEnumerable<SatelliteConfig> satellites,
+        CancellationToken cancellationToken = default)
+    {
+        // Clear cache for these satellites first
+        foreach (var sat in satellites)
+        {
+            ClearCacheFor(sat.NoradId);
+        }
+
+        return await GetTleForSatellitesAsync(satellites, cancellationToken);
+    }
+
+    private string GetCacheFilePath(int noradId)
+    {
+        return Path.Combine(CacheDirectory, $"tle_{noradId}.json");
+    }
+
+    private void EnsureCacheDirectoryExists()
+    {
+        if (!Directory.Exists(CacheDirectory))
+        {
+            Directory.CreateDirectory(CacheDirectory);
+        }
+    }
+
+    /// <summary>
+    /// Cache entry for TLE data.
+    /// </summary>
+    private class TleCacheEntry
+    {
+        public TleData? TleData { get; set; }
+        public DateTime CachedAt { get; set; }
+    }
+}
+
+/// <summary>
+/// Information about a cached satellite TLE.
+/// </summary>
+public class SatelliteCacheInfo
+{
+    /// <summary>Gets or sets the NORAD catalog number.</summary>
+    public int NoradId { get; set; }
+
+    /// <summary>Gets or sets the satellite name.</summary>
+    public string SatelliteName { get; set; } = string.Empty;
+
+    /// <summary>Gets or sets when the data was cached.</summary>
+    public DateTime CachedAt { get; set; }
+
+    /// <summary>Gets or sets the age of the cache entry.</summary>
+    public TimeSpan Age { get; set; }
+
+    /// <summary>Gets or sets the TLE epoch date.</summary>
+    public DateTime EpochDate { get; set; }
+
+    /// <summary>Gets whether the cache is fresh (less than 7 days).</summary>
+    public bool IsFresh => Age.TotalHours < BatchTleService.DefaultCacheExpirationHours;
+}

--- a/Shared/Services/LagrangePointDetector.cs
+++ b/Shared/Services/LagrangePointDetector.cs
@@ -1,0 +1,236 @@
+namespace WorldMapWallpaper.Shared.Services;
+
+/// <summary>
+/// Detects satellites at Lagrange points that cannot be accurately projected onto an Earth-centered map.
+/// </summary>
+public static class LagrangePointDetector
+{
+    /// <summary>
+    /// Semi-major axis threshold in kilometers. Satellites with orbits larger than this
+    /// are likely at Lagrange points or in heliocentric orbits.
+    /// Earth's sphere of influence is approximately 925,000 km, and L1/L2 are at ~1.5 million km.
+    /// </summary>
+    private const double SemiMajorAxisThresholdKm = 500_000;
+
+    /// <summary>
+    /// Known Lagrange point satellites by NORAD ID.
+    /// </summary>
+    private static readonly Dictionary<int, LagrangePointInfo> KnownLagrangePointSatellites = new()
+    {
+        { 50463, new LagrangePointInfo("James Webb Space Telescope", "L2", 1_500_000) },
+        { 43435, new LagrangePointInfo("DSCOVR", "L1", 1_500_000) },
+        { 39479, new LagrangePointInfo("Gaia", "L2", 1_500_000) },
+        { 28928, new LagrangePointInfo("SOHO", "L1", 1_500_000) },
+        { 52195, new LagrangePointInfo("Euclid", "L2", 1_500_000) },
+    };
+
+    /// <summary>
+    /// Checks if a satellite is known to be at a Lagrange point.
+    /// </summary>
+    /// <param name="noradId">The NORAD catalog number.</param>
+    /// <returns>True if the satellite is known to be at a Lagrange point.</returns>
+    public static bool IsKnownLagrangePointSatellite(int noradId)
+    {
+        return KnownLagrangePointSatellites.ContainsKey(noradId);
+    }
+
+    /// <summary>
+    /// Gets information about a known Lagrange point satellite.
+    /// </summary>
+    /// <param name="noradId">The NORAD catalog number.</param>
+    /// <returns>Lagrange point info if known, null otherwise.</returns>
+    public static LagrangePointInfo? GetLagrangePointInfo(int noradId)
+    {
+        return KnownLagrangePointSatellites.TryGetValue(noradId, out var info) ? info : null;
+    }
+
+    /// <summary>
+    /// Checks if a semi-major axis indicates a potential Lagrange point orbit.
+    /// </summary>
+    /// <param name="semiMajorAxisKm">The semi-major axis in kilometers.</param>
+    /// <returns>True if the orbit is suspiciously large for Earth orbit.</returns>
+    public static bool IsPotentialLagrangePointOrbit(double semiMajorAxisKm)
+    {
+        return semiMajorAxisKm > SemiMajorAxisThresholdKm;
+    }
+
+    /// <summary>
+    /// Calculates the semi-major axis from TLE mean motion.
+    /// </summary>
+    /// <param name="meanMotionRevsPerDay">Mean motion in revolutions per day from TLE.</param>
+    /// <returns>Semi-major axis in kilometers.</returns>
+    public static double CalculateSemiMajorAxisFromMeanMotion(double meanMotionRevsPerDay)
+    {
+        // Kepler's third law: a^3 = GM / (2*pi*n)^2
+        // Where:
+        //   a = semi-major axis
+        //   GM = Earth's gravitational parameter = 398600.4418 km^3/s^2
+        //   n = mean motion in radians/second
+
+        const double EarthGM = 398600.4418; // km^3/s^2
+
+        // Convert revs/day to radians/second
+        var meanMotionRadPerSec = meanMotionRevsPerDay * 2 * Math.PI / 86400.0;
+
+        if (meanMotionRadPerSec <= 0)
+            return double.MaxValue; // Invalid mean motion
+
+        // a = (GM / n^2)^(1/3)
+        var semiMajorAxis = Math.Pow(EarthGM / (meanMotionRadPerSec * meanMotionRadPerSec), 1.0 / 3.0);
+
+        return semiMajorAxis;
+    }
+
+    /// <summary>
+    /// Performs a comprehensive check to determine if a satellite might be at a Lagrange point.
+    /// </summary>
+    /// <param name="noradId">The NORAD catalog number.</param>
+    /// <param name="meanMotionRevsPerDay">Mean motion from TLE (optional).</param>
+    /// <returns>Detection result with details.</returns>
+    public static LagrangePointDetectionResult DetectLagrangePoint(int noradId, double? meanMotionRevsPerDay = null)
+    {
+        // First check known satellites
+        if (KnownLagrangePointSatellites.TryGetValue(noradId, out var knownInfo))
+        {
+            return new LagrangePointDetectionResult
+            {
+                IsLagrangePoint = true,
+                Confidence = DetectionConfidence.Definite,
+                LagrangePoint = knownInfo.LagrangePoint,
+                DistanceFromEarthKm = knownInfo.ApproximateDistanceKm,
+                SatelliteName = knownInfo.Name,
+                Message = $"{knownInfo.Name} is located at Lagrange Point {knownInfo.LagrangePoint}, " +
+                          $"approximately {knownInfo.ApproximateDistanceKm / 1_000_000.0:F1} million km from Earth."
+            };
+        }
+
+        // If we have mean motion, check orbital characteristics
+        if (meanMotionRevsPerDay.HasValue && meanMotionRevsPerDay.Value > 0)
+        {
+            var semiMajorAxis = CalculateSemiMajorAxisFromMeanMotion(meanMotionRevsPerDay.Value);
+
+            if (IsPotentialLagrangePointOrbit(semiMajorAxis))
+            {
+                return new LagrangePointDetectionResult
+                {
+                    IsLagrangePoint = true,
+                    Confidence = DetectionConfidence.Suspected,
+                    DistanceFromEarthKm = semiMajorAxis,
+                    Message = $"This satellite has an orbital semi-major axis of {semiMajorAxis:N0} km, " +
+                              $"which suggests it may be at a Lagrange point or in a distant orbit."
+                };
+            }
+        }
+
+        // Not detected as Lagrange point
+        return new LagrangePointDetectionResult
+        {
+            IsLagrangePoint = false,
+            Confidence = DetectionConfidence.NotLagrangePoint,
+            Message = "This satellite appears to be in a standard Earth orbit."
+        };
+    }
+
+    /// <summary>
+    /// Gets the warning message for displaying to users when adding a Lagrange point satellite.
+    /// </summary>
+    /// <param name="result">The detection result.</param>
+    /// <returns>A formatted warning message.</returns>
+    public static string GetWarningMessage(LagrangePointDetectionResult result)
+    {
+        if (!result.IsLagrangePoint)
+            return string.Empty;
+
+        var lines = new List<string>
+        {
+            result.Message,
+            string.Empty,
+            "Satellites at Lagrange points cannot be correctly projected onto the Earth map.",
+            "The position shown will not be accurate."
+        };
+
+        return string.Join(Environment.NewLine, lines);
+    }
+}
+
+/// <summary>
+/// Information about a known Lagrange point satellite.
+/// </summary>
+public class LagrangePointInfo
+{
+    /// <summary>
+    /// Gets the satellite name.
+    /// </summary>
+    public string Name { get; }
+
+    /// <summary>
+    /// Gets the Lagrange point (L1, L2, etc.).
+    /// </summary>
+    public string LagrangePoint { get; }
+
+    /// <summary>
+    /// Gets the approximate distance from Earth in kilometers.
+    /// </summary>
+    public double ApproximateDistanceKm { get; }
+
+    /// <summary>
+    /// Creates a new instance of LagrangePointInfo.
+    /// </summary>
+    public LagrangePointInfo(string name, string lagrangePoint, double approximateDistanceKm)
+    {
+        Name = name;
+        LagrangePoint = lagrangePoint;
+        ApproximateDistanceKm = approximateDistanceKm;
+    }
+}
+
+/// <summary>
+/// Result of Lagrange point detection.
+/// </summary>
+public class LagrangePointDetectionResult
+{
+    /// <summary>
+    /// Gets or sets whether the satellite is detected as being at a Lagrange point.
+    /// </summary>
+    public bool IsLagrangePoint { get; set; }
+
+    /// <summary>
+    /// Gets or sets the confidence level of the detection.
+    /// </summary>
+    public DetectionConfidence Confidence { get; set; }
+
+    /// <summary>
+    /// Gets or sets the Lagrange point (L1, L2, etc.) if known.
+    /// </summary>
+    public string? LagrangePoint { get; set; }
+
+    /// <summary>
+    /// Gets or sets the approximate distance from Earth in kilometers.
+    /// </summary>
+    public double? DistanceFromEarthKm { get; set; }
+
+    /// <summary>
+    /// Gets or sets the satellite name if known.
+    /// </summary>
+    public string? SatelliteName { get; set; }
+
+    /// <summary>
+    /// Gets or sets a human-readable message about the detection.
+    /// </summary>
+    public string Message { get; set; } = string.Empty;
+}
+
+/// <summary>
+/// Confidence level for Lagrange point detection.
+/// </summary>
+public enum DetectionConfidence
+{
+    /// <summary>Not detected as a Lagrange point satellite.</summary>
+    NotLagrangePoint,
+
+    /// <summary>Suspected based on orbital characteristics.</summary>
+    Suspected,
+
+    /// <summary>Definitively known to be at a Lagrange point.</summary>
+    Definite
+}

--- a/Shared/Services/SatelliteConfigManager.cs
+++ b/Shared/Services/SatelliteConfigManager.cs
@@ -1,0 +1,371 @@
+using System.Text.Json;
+using WorldMapWallpaper.Shared.Models;
+
+namespace WorldMapWallpaper.Shared.Services;
+
+/// <summary>
+/// Manages loading, saving, and manipulating satellite configurations.
+/// </summary>
+public class SatelliteConfigManager
+{
+    private static readonly string ConfigDirectory =
+        Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), "WorldMapWallpaper");
+
+    private static readonly string ConfigFilePath =
+        Path.Combine(ConfigDirectory, "satellites.json");
+
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        WriteIndented = true,
+        PropertyNameCaseInsensitive = true
+    };
+
+    private SatelliteConfigRoot _config;
+    private static SatelliteConfigManager? _instance;
+    private static readonly object _lock = new();
+
+    /// <summary>
+    /// Gets the singleton instance of the SatelliteConfigManager.
+    /// </summary>
+    public static SatelliteConfigManager Instance
+    {
+        get
+        {
+            if (_instance == null)
+            {
+                lock (_lock)
+                {
+                    _instance ??= new SatelliteConfigManager();
+                }
+            }
+            return _instance;
+        }
+    }
+
+    private SatelliteConfigManager()
+    {
+        _config = Load();
+    }
+
+    /// <summary>
+    /// Gets the current configuration.
+    /// </summary>
+    public SatelliteConfigRoot Config => _config;
+
+    /// <summary>
+    /// Gets or sets the maximum number of visible satellites.
+    /// </summary>
+    public int MaxVisibleSatellites
+    {
+        get => _config.MaxVisibleSatellites;
+        set
+        {
+            _config.MaxVisibleSatellites = Math.Clamp(value, 1, 15);
+            Save();
+        }
+    }
+
+    /// <summary>
+    /// Gets or sets the visibility mode.
+    /// </summary>
+    public SatelliteVisibilityMode VisibilityMode
+    {
+        get => _config.VisibilityMode;
+        set
+        {
+            _config.VisibilityMode = value;
+            Save();
+        }
+    }
+
+    /// <summary>
+    /// Gets all configured satellites.
+    /// </summary>
+    public IReadOnlyList<SatelliteConfig> Satellites => _config.Satellites.AsReadOnly();
+
+    /// <summary>
+    /// Gets enabled satellites sorted by priority, limited to max visible.
+    /// </summary>
+    public IEnumerable<SatelliteConfig> GetVisibleSatellites()
+    {
+        return _config.Satellites
+            .Where(s => s.Enabled)
+            .OrderBy(s => s.Priority)
+            .Take(_config.MaxVisibleSatellites);
+    }
+
+    /// <summary>
+    /// Adds a new satellite to the configuration.
+    /// </summary>
+    /// <param name="satellite">The satellite configuration to add.</param>
+    /// <returns>True if added, false if already exists.</returns>
+    public bool AddSatellite(SatelliteConfig satellite)
+    {
+        if (_config.Satellites.Any(s => s.NoradId == satellite.NoradId))
+            return false;
+
+        // Auto-assign priority if not set
+        if (satellite.Priority == 100)
+        {
+            satellite.Priority = _config.Satellites.Count > 0
+                ? _config.Satellites.Max(s => s.Priority) + 1
+                : 1;
+        }
+
+        // Auto-assign color if not set
+        if (string.IsNullOrEmpty(satellite.Color))
+        {
+            satellite.Color = SatellitePreset.GetSuggestedColor(_config.Satellites.Count);
+        }
+
+        _config.Satellites.Add(satellite);
+        Save();
+        return true;
+    }
+
+    /// <summary>
+    /// Adds a satellite from a preset.
+    /// </summary>
+    /// <param name="preset">The preset to add.</param>
+    /// <returns>True if added, false if already exists.</returns>
+    public bool AddFromPreset(SatellitePreset preset)
+    {
+        if (_config.Satellites.Any(s => s.NoradId == preset.NoradId))
+            return false;
+
+        var priority = _config.Satellites.Count > 0
+            ? _config.Satellites.Max(s => s.Priority) + 1
+            : 1;
+
+        var config = preset.ToConfig(priority);
+        _config.Satellites.Add(config);
+        Save();
+        return true;
+    }
+
+    /// <summary>
+    /// Updates an existing satellite configuration.
+    /// </summary>
+    /// <param name="satellite">The updated satellite configuration.</param>
+    /// <returns>True if updated, false if not found.</returns>
+    public bool UpdateSatellite(SatelliteConfig satellite)
+    {
+        var index = _config.Satellites.FindIndex(s => s.NoradId == satellite.NoradId);
+        if (index < 0)
+            return false;
+
+        _config.Satellites[index] = satellite;
+        Save();
+        return true;
+    }
+
+    /// <summary>
+    /// Removes a satellite by NORAD ID.
+    /// </summary>
+    /// <param name="noradId">The NORAD ID of the satellite to remove.</param>
+    /// <returns>True if removed, false if not found.</returns>
+    public bool RemoveSatellite(int noradId)
+    {
+        var satellite = _config.Satellites.FirstOrDefault(s => s.NoradId == noradId);
+        if (satellite == null)
+            return false;
+
+        _config.Satellites.Remove(satellite);
+        Save();
+        return true;
+    }
+
+    /// <summary>
+    /// Sets the enabled state of a satellite.
+    /// </summary>
+    /// <param name="noradId">The NORAD ID.</param>
+    /// <param name="enabled">Whether the satellite should be enabled.</param>
+    /// <returns>True if updated, false if not found.</returns>
+    public bool SetSatelliteEnabled(int noradId, bool enabled)
+    {
+        var satellite = _config.Satellites.FirstOrDefault(s => s.NoradId == noradId);
+        if (satellite == null)
+            return false;
+
+        satellite.Enabled = enabled;
+        Save();
+        return true;
+    }
+
+    /// <summary>
+    /// Reorders satellites by priority.
+    /// </summary>
+    /// <param name="noradIds">NORAD IDs in the desired priority order.</param>
+    public void ReorderSatellites(IEnumerable<int> noradIds)
+    {
+        var priority = 1;
+        foreach (var noradId in noradIds)
+        {
+            var satellite = _config.Satellites.FirstOrDefault(s => s.NoradId == noradId);
+            if (satellite != null)
+            {
+                satellite.Priority = priority++;
+            }
+        }
+        Save();
+    }
+
+    /// <summary>
+    /// Checks if a satellite with the given NORAD ID exists.
+    /// </summary>
+    /// <param name="noradId">The NORAD ID to check.</param>
+    /// <returns>True if exists, false otherwise.</returns>
+    public bool ContainsSatellite(int noradId)
+    {
+        return _config.Satellites.Any(s => s.NoradId == noradId);
+    }
+
+    /// <summary>
+    /// Gets a satellite by NORAD ID.
+    /// </summary>
+    /// <param name="noradId">The NORAD ID.</param>
+    /// <returns>The satellite config, or null if not found.</returns>
+    public SatelliteConfig? GetSatellite(int noradId)
+    {
+        return _config.Satellites.FirstOrDefault(s => s.NoradId == noradId);
+    }
+
+    /// <summary>
+    /// Exports the current configuration to a file.
+    /// </summary>
+    /// <param name="filePath">The file path to export to.</param>
+    public void Export(string filePath)
+    {
+        var json = JsonSerializer.Serialize(_config, JsonOptions);
+        File.WriteAllText(filePath, json);
+    }
+
+    /// <summary>
+    /// Imports configuration from a file.
+    /// </summary>
+    /// <param name="filePath">The file path to import from.</param>
+    /// <param name="mergeMode">If true, merge with existing; if false, replace all.</param>
+    /// <returns>The number of satellites imported.</returns>
+    public int Import(string filePath, bool mergeMode)
+    {
+        var json = File.ReadAllText(filePath);
+        var imported = JsonSerializer.Deserialize<SatelliteConfigRoot>(json, JsonOptions);
+
+        if (imported == null)
+            return 0;
+
+        var count = 0;
+
+        if (mergeMode)
+        {
+            // Merge: update existing, add new
+            foreach (var satellite in imported.Satellites)
+            {
+                var existing = _config.Satellites.FirstOrDefault(s => s.NoradId == satellite.NoradId);
+                if (existing != null)
+                {
+                    // Update existing
+                    var index = _config.Satellites.IndexOf(existing);
+                    _config.Satellites[index] = satellite;
+                }
+                else
+                {
+                    // Add new
+                    _config.Satellites.Add(satellite);
+                }
+                count++;
+            }
+        }
+        else
+        {
+            // Replace all
+            _config.Satellites = imported.Satellites;
+            count = imported.Satellites.Count;
+        }
+
+        // Also import settings
+        _config.MaxVisibleSatellites = Math.Clamp(imported.MaxVisibleSatellites, 1, 15);
+        _config.VisibilityMode = imported.VisibilityMode;
+
+        Save();
+        return count;
+    }
+
+    /// <summary>
+    /// Reloads the configuration from disk.
+    /// </summary>
+    public void Reload()
+    {
+        _config = Load();
+    }
+
+    /// <summary>
+    /// Resets the configuration to defaults (ISS only).
+    /// </summary>
+    public void ResetToDefaults()
+    {
+        _config = CreateDefault();
+        Save();
+    }
+
+    /// <summary>
+    /// Saves the current configuration to disk.
+    /// </summary>
+    public void Save()
+    {
+        try
+        {
+            EnsureDirectoryExists();
+            var json = JsonSerializer.Serialize(_config, JsonOptions);
+            File.WriteAllText(ConfigFilePath, json);
+        }
+        catch
+        {
+            // Silently fail - configuration will use in-memory values
+        }
+    }
+
+    private SatelliteConfigRoot Load()
+    {
+        try
+        {
+            if (File.Exists(ConfigFilePath))
+            {
+                var json = File.ReadAllText(ConfigFilePath);
+                var config = JsonSerializer.Deserialize<SatelliteConfigRoot>(json, JsonOptions);
+                if (config != null)
+                    return config;
+            }
+        }
+        catch
+        {
+            // Fall through to create default
+        }
+
+        // Create default configuration with ISS
+        var defaultConfig = CreateDefault();
+        Save();
+        return defaultConfig;
+    }
+
+    private static SatelliteConfigRoot CreateDefault()
+    {
+        var issPreset = SatellitePreset.FindByNoradId(25544);
+        var config = new SatelliteConfigRoot();
+
+        if (issPreset != null)
+        {
+            config.Satellites.Add(issPreset.ToConfig(1));
+        }
+
+        return config;
+    }
+
+    private static void EnsureDirectoryExists()
+    {
+        if (!Directory.Exists(ConfigDirectory))
+        {
+            Directory.CreateDirectory(ConfigDirectory);
+        }
+    }
+}

--- a/Shared/Services/SatelliteConfigManager.cs
+++ b/Shared/Services/SatelliteConfigManager.cs
@@ -255,11 +255,12 @@ public class SatelliteConfigManager
             return 0;
 
         var count = 0;
+        var importedSatellites = imported.Satellites ?? new List<SatelliteConfig>();
 
         if (mergeMode)
         {
             // Merge: update existing, add new
-            foreach (var satellite in imported.Satellites)
+            foreach (var satellite in importedSatellites)
             {
                 var existing = _config.Satellites.FirstOrDefault(s => s.NoradId == satellite.NoradId);
                 if (existing != null)
@@ -279,8 +280,8 @@ public class SatelliteConfigManager
         else
         {
             // Replace all
-            _config.Satellites = imported.Satellites;
-            count = imported.Satellites.Count;
+            _config.Satellites = importedSatellites;
+            count = _config.Satellites.Count;
         }
 
         // Also import settings
@@ -344,6 +345,7 @@ public class SatelliteConfigManager
 
         // Create default configuration with ISS
         var defaultConfig = CreateDefault();
+        _config = defaultConfig;
         Save();
         return defaultConfig;
     }

--- a/Shared/Settings.cs
+++ b/Shared/Settings.cs
@@ -83,6 +83,16 @@ public static class Settings
     }
 
     /// <summary>
+    /// Gets or sets whether satellite tracking is enabled.
+    /// This is the master switch for all satellite tracking features.
+    /// </summary>
+    public static bool SatelliteTrackingEnabled
+    {
+        get => GetBoolSetting("SatelliteTrackingEnabled", true);
+        set => SetBoolSetting("SatelliteTrackingEnabled", value);
+    }
+
+    /// <summary>
     /// Gets a boolean setting from the registry.
     /// </summary>
     /// <param name="name">The setting name.</param>
@@ -211,5 +221,6 @@ public static class Settings
         ResolutionMode = ResolutionMode.None;
         CustomResolutionWidth = 0;
         CustomResolutionHeight = 0;
+        SatelliteTrackingEnabled = true;
     }
 }

--- a/Shared/ThemeManager.cs
+++ b/Shared/ThemeManager.cs
@@ -57,7 +57,8 @@ public static class ThemeManager
             ButtonHoverColor = Color.FromArgb(70, 70, 70),       // Button hover
             GroupBoxBackColor = Color.FromArgb(40, 40, 40),      // GroupBox background
             SuccessColor = Color.FromArgb(16, 124, 16),          // Dark green
-            ErrorColor = Color.FromArgb(196, 43, 28)             // Dark red
+            ErrorColor = Color.FromArgb(196, 43, 28),            // Dark red
+            WarningColor = Color.FromArgb(255, 185, 0)           // Warning orange
         };
     }
 
@@ -79,7 +80,8 @@ public static class ThemeManager
             ButtonHoverColor = Color.FromArgb(230, 230, 230),    // Button hover
             GroupBoxBackColor = Color.FromArgb(248, 248, 248),   // GroupBox background
             SuccessColor = Color.FromArgb(16, 124, 16),          // Green
-            ErrorColor = Color.FromArgb(196, 43, 28)             // Red
+            ErrorColor = Color.FromArgb(196, 43, 28),            // Red
+            WarningColor = Color.FromArgb(210, 140, 0)           // Warning orange
         };
     }
 }
@@ -100,4 +102,5 @@ public class ColorScheme
     public Color GroupBoxBackColor { get; set; }
     public Color SuccessColor { get; set; }
     public Color ErrorColor { get; set; }
+    public Color WarningColor { get; set; }
 }

--- a/WorldMapWallpaper.sln
+++ b/WorldMapWallpaper.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 18
-VisualStudioVersion = 18.2.11415.280 d18.0
+VisualStudioVersion = 18.2.11415.280
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "WorldMapWallpaper", "ImagePainter\WorldMapWallpaper.csproj", "{1290D9DD-B84C-4CED-8BE7-30B491882180}"
 EndProject
@@ -10,6 +10,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		.editorconfig = .editorconfig
 		.gitattributes = .gitattributes
 		.gitignore = .gitignore
+		AGENTS.md = AGENTS.md
 		build.bat = build.bat
 		CHANGELOG.md = CHANGELOG.md
 		CLAUDE.md = CLAUDE.md

--- a/docs/CustomSatellites-Feature-Proposal.md
+++ b/docs/CustomSatellites-Feature-Proposal.md
@@ -1,0 +1,815 @@
+# Custom Satellites Feature Proposal
+
+## Overview
+
+This document outlines a proposed enhancement to WorldMapWallpaper that would allow users to track multiple satellites beyond just the International Space Station (ISS). Users would be able to add custom satellites using NORAD catalog numbers, specify custom icons for each, and have fine-grained control over visibility.
+
+---
+
+## 1. Custom Satellite Support
+
+### 1.1 Satellite Configuration
+
+Users should be able to add satellites by specifying:
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `Name` | string | Yes | Display name (e.g., "Hubble Space Telescope") |
+| `NoradId` | int | Yes | NORAD catalog number (e.g., 20580 for Hubble) |
+| `Enabled` | bool | Yes | Whether to display this satellite |
+| `IconPath` | string | No | Path to custom icon (null = use default) |
+| `Color` | Color | No | Orbit trail color (null = auto-assign from palette) |
+| `ShowOrbit` | bool | No | Whether to show orbital path (default: true) |
+| `Priority` | int | No | Display priority when limit is reached (lower = higher priority) |
+
+### 1.2 Data Storage
+
+Satellites should be stored in a JSON configuration file:
+
+**Location:** `%APPDATA%\WorldMapWallpaper\satellites.json`
+
+```json
+{
+  "version": 1,
+  "maxVisibleSatellites": 5,
+  "defaultOrbitPoints": 50,
+  "satellites": [
+    {
+      "name": "International Space Station",
+      "noradId": 25544,
+      "enabled": true,
+      "iconPath": null,
+      "color": "#FF6B35",
+      "showOrbit": true,
+      "priority": 1
+    },
+    {
+      "name": "Hubble Space Telescope",
+      "noradId": 20580,
+      "enabled": true,
+      "iconPath": "C:\\Users\\user\\icons\\hubble.png",
+      "color": "#4ECDC4",
+      "showOrbit": true,
+      "priority": 2
+    },
+    {
+      "name": "Tiangong Space Station",
+      "noradId": 48274,
+      "enabled": true,
+      "iconPath": null,
+      "color": "#FFE66D",
+      "showOrbit": true,
+      "priority": 3
+    }
+  ]
+}
+```
+
+### 1.3 Lagrange Point Detection
+
+Satellites at Lagrange points (L1, L2, L3, L4, L5) cannot be accurately projected onto an Earth-centered map. The application must:
+
+1. **Detect Lagrange Point Satellites:** Maintain a list of known Lagrange point satellites:
+   | NORAD ID | Name | Location |
+   |----------|------|----------|
+   | 50463 | James Webb Space Telescope | L2 |
+   | 43435 | DSCOVR | L1 |
+   | 39479 | Gaia | L2 |
+   | 28928 | SOHO | L1 |
+   | 52195 | Euclid | L2 |
+
+2. **Orbital Detection:** If semi-major axis > 500,000 km, flag as potential Lagrange point
+
+3. **User Warning:** When user attempts to add a Lagrange point satellite:
+   ```
+   +--------------------------------------------------+
+   |  Warning                                    [X]  |
+   +--------------------------------------------------+
+   |                                                   |
+   |  [!] James Webb Space Telescope is located at    |
+   |      Lagrange Point L2, approximately 1.5        |
+   |      million km from Earth.                      |
+   |                                                   |
+   |      Satellites at Lagrange points cannot be     |
+   |      correctly projected onto the Earth map.     |
+   |      The position shown will not be accurate.    |
+   |                                                   |
+   |      Do you still want to add this satellite?    |
+   |                                                   |
+   |              [Cancel]  [Add Anyway]              |
+   +--------------------------------------------------+
+   ```
+
+4. **Visual Indicator:** If added anyway, show with a distinct indicator (e.g., "~" prefix or different icon border) to remind user it's not accurately positioned.
+
+### 1.4 Preset Satellites
+
+Include a set of well-known Earth-orbiting satellites as presets:
+
+| Name | NORAD ID | Category | Orbit |
+|------|----------|----------|-------|
+| International Space Station | 25544 | Space Station | LEO |
+| Tiangong Space Station | 48274 | Space Station | LEO |
+| Hubble Space Telescope | 20580 | Science | LEO |
+| Landsat 9 | 49260 | Earth Observation | LEO |
+| GOES-18 | 51850 | Weather | GEO |
+| NOAA-20 | 43013 | Weather | LEO |
+| Terra | 25994 | Earth Science | LEO |
+| Aqua | 27424 | Earth Science | LEO |
+| GPS IIF-12 | 41019 | Navigation | MEO |
+| Sentinel-2A | 40697 | Earth Observation | LEO |
+
+**Note:** Satellite constellations (Starlink, OneWeb, etc.) are excluded because individual satellites change frequently and cannot be reliably tracked over time.
+
+### 1.5 TLE Data Management
+
+#### Fetching Strategy
+
+```
+Maximum Satellites: 50 (hard limit)
+Request Timeout: 5 seconds per request
+```
+
+**Batch Request (Preferred):**
+```
+GET https://celestrak.org/NORAD/elements/gp.php?CATNR=25544,20580,48274&FORMAT=TLE
+```
+
+If batch requests are supported, fetch all enabled satellites in a single request.
+
+**Parallel Async Fallback:**
+If batch is not supported or fails, make parallel async requests:
+
+```csharp
+public async Task<Dictionary<int, TleData>> FetchMultipleTleAsync(
+    IEnumerable<int> noradIds,
+    CancellationToken cancellationToken)
+{
+    var results = new ConcurrentDictionary<int, TleData>();
+    var tasks = noradIds.Select(async id =>
+    {
+        using var cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        cts.CancelAfter(TimeSpan.FromSeconds(5)); // 5s timeout per request
+
+        try
+        {
+            var tle = await FetchSingleTleAsync(id, cts.Token);
+            results.TryAdd(id, tle);
+        }
+        catch (OperationCanceledException)
+        {
+            // Timeout - will use cache fallback
+        }
+        catch (Exception)
+        {
+            // Network error - will use cache fallback
+        }
+    });
+
+    await Task.WhenAll(tasks);
+    return results.ToDictionary(kv => kv.Key, kv => kv.Value);
+}
+```
+
+#### Fallback Strategy
+
+```
+1. Try batch API request (5s timeout)
+   |
+   +-- Success --> Cache results, return fresh TLE data
+   |
+   +-- Timeout/Failure --> Try parallel individual requests
+                           |
+                           +-- For each satellite:
+                               |
+                               +-- Success --> Cache, use fresh
+                               |
+                               +-- Timeout --> Check cache
+                                               |
+                                               +-- Cache valid --> Use cached TLE for orbital calculation
+                                               |
+                                               +-- Cache expired/missing --> Skip satellite (don't display)
+```
+
+#### Cache Configuration
+
+```json
+{
+  "tleCacheDirectory": "%APPDATA%\\WorldMapWallpaper\\tle_cache\\",
+  "cacheExpirationHours": 168,  // 7 days
+  "staleDataMaxAgeDays": 30     // Use stale data up to 30 days if no network
+}
+```
+
+---
+
+## 2. Custom Icons
+
+### 2.1 Icon Specifications
+
+| Property | Requirement |
+|----------|-------------|
+| Format | PNG with transparency (preferred), ICO, BMP |
+| Size | 32x32 pixels (recommended), will be scaled if different |
+| Color Mode | RGBA (32-bit with alpha channel) |
+| File Size | Max 256 KB |
+
+### 2.2 Default Icons
+
+Provide a set of built-in icons for common satellite types:
+
+```
+Resources/
+  Icons/
+    satellite-default.png    # Generic satellite
+    satellite-station.png    # Space stations (ISS, Tiangong)
+    satellite-telescope.png  # Telescopes (Hubble)
+    satellite-weather.png    # Weather satellites (GOES, NOAA)
+    satellite-earth-obs.png  # Earth observation (Landsat, Sentinel)
+    satellite-science.png    # Science satellites (Terra, Aqua)
+    satellite-gps.png        # Navigation satellites
+```
+
+### 2.3 Icon Assignment Logic
+
+```
+1. If custom IconPath is specified and file exists --> use custom icon
+2. Else if satellite category is known --> use category-specific icon
+3. Else --> use satellite-default.png
+```
+
+### 2.4 Icon Scaling
+
+- Icons are scaled to fit within a 24x24 to 48x48 pixel bounding box
+- Use high-quality bicubic interpolation for scaling
+- Maintain aspect ratio (no stretching)
+
+---
+
+## 3. Orbit Trail Colors
+
+### 3.1 Auto-Assignment with User Override
+
+The application provides suggested colors from a visually distinct palette, but users can customize:
+
+**Default Color Palette:**
+```csharp
+private static readonly string[] DefaultOrbitColors =
+{
+    "#FF6B35",  // Orange (ISS default)
+    "#4ECDC4",  // Teal
+    "#FFE66D",  // Yellow
+    "#95E1D3",  // Mint
+    "#F38181",  // Coral
+    "#AA96DA",  // Lavender
+    "#81B214",  // Green
+    "#2C786C",  // Dark Teal
+    "#F9ED69",  // Light Yellow
+    "#B83B5E",  // Magenta
+};
+```
+
+**Assignment Logic:**
+1. New satellite gets next unused color from palette
+2. If all colors used, cycle back with slight variation
+3. User can override via color picker in Edit dialog
+4. Custom colors saved to satellite configuration
+
+**Color Picker in UI:**
+```
+Color: [#FF6B35] [Pick...] [Reset to Suggested]
+       [Preview swatch showing orbit trail sample]
+```
+
+---
+
+## 4. Satellite Visibility Limits
+
+### 4.1 Performance Limits
+
+| Setting | Min | Default | Max | Notes |
+|---------|-----|---------|-----|-------|
+| Max Visible Satellites | 1 | 5 | 15 | UI enforced |
+| Max Configurable Satellites | - | - | 50 | Total in config file |
+| Orbit Trail Points | 20 | 50 | 100 | Points before + after |
+| Orbit Trail Width | 1 | 2 | 5 | Pixels |
+
+### 4.2 Priority System
+
+When more satellites are enabled than the visibility limit:
+
+1. Sort enabled satellites by `Priority` (ascending, lower = higher priority)
+2. Take the first N satellites where N = `maxVisibleSatellites`
+3. Satellites with failed TLE data are skipped (don't count against limit)
+
+**Priority UI:**
+- Drag-and-drop reordering in satellite list
+- Or explicit priority number field in Edit dialog
+- Priority auto-assigned on add (next available number)
+
+### 4.3 Visibility Modes
+
+| Mode | Description |
+|------|-------------|
+| `All` | Show all enabled satellites (up to limit) |
+| `DaylightOnly` | Only show satellites currently in sunlight |
+
+**Future consideration:** `VisibleFromLocation` mode requiring user's geographic coordinates.
+
+---
+
+## 5. Settings UI Redesign
+
+### 5.1 Design Principles
+
+- **Tabbed Interface:** Organize related settings into logical groups
+- **Live Preview:** Real-time thumbnail showing wallpaper with current settings
+- **Consistent Theme:** Leverage existing dark/light mode support
+- **Responsive:** Accommodate new satellite management features
+
+### 5.2 Main Window Layout
+
+```
++----------------------------------------------------------+
+|  World Map Wallpaper Settings                        [X]  |
++----------------------------------------------------------+
+|  [Display]  [Satellites]  [Schedule]  [Advanced]         |
++----------------------------------------------------------+
+|                                                           |
+|  +-----------------------------------------------------+ |
+|  |                                                     | |
+|  |                  (Tab content area)                 | |
+|  |                                                     | |
+|  |                                                     | |
+|  +-----------------------------------------------------+ |
+|                                                           |
+|  LIVE PREVIEW                                             |
+|  +-----------------------------------------------------+ |
+|  |                                                     | |
+|  |              [Live Thumbnail 320x180]               | |
+|  |                                                     | |
+|  +-----------------------------------------------------+ |
+|  Last updated: 2 seconds ago          [Refresh Preview]  |
+|                                                           |
++----------------------------------------------------------+
+|  [Update Wallpaper Now]              [Reset All] [Close] |
++----------------------------------------------------------+
+```
+
+### 5.3 Tab: Display
+
+```
++----------------------------------------------------------+
+| VISUAL ELEMENTS                                           |
+| +------------------------------------------------------+ |
+| | [x] Show time zone clocks around the world           | |
+| | [x] Show political boundaries and country borders    | |
+| +------------------------------------------------------+ |
+|                                                           |
+| RESOLUTION                                                |
+| +------------------------------------------------------+ |
+| | Mode: [Fit to Screen          v]                     | |
+| | Detected: 2560 x 1440                                | |
+| |                                                       | |
+| | Custom: [    0    ] x [    0    ]                    | |
+| | (Set both to 0 to use detected resolution)           | |
+| +------------------------------------------------------+ |
++----------------------------------------------------------+
+```
+
+### 5.4 Tab: Satellites
+
+```
++----------------------------------------------------------+
+| SATELLITE TRACKING                                        |
+| +------------------------------------------------------+ |
+| | [x] Enable satellite tracking                         | |
+| |                                                       | |
+| | Max visible satellites: [  5  v]  (1-15)             | |
+| | Visibility mode: [All satellites  v]                 | |
+| +------------------------------------------------------+ |
+|                                                           |
+| TRACKED SATELLITES                          [Import]      |
+| +------------------------------------------------------+ |
+| | # | On |      Name                 | NORAD | Actions | |
+| |---|----|-----------------------------|-------|---------|
+| | 1 | [x]| [O] International Space... | 25544 | [Edit]  | |
+| | 2 | [x]| [O] Hubble Space Telescope | 20580 | [Edit]  | |
+| | 3 | [ ]| [O] Tiangong Space Station | 48274 | [Edit]  | |
+| |   |    |                             |       |         | |
+| +------------------------------------------------------+ |
+| | Drag rows to reorder priority. Lower = higher priority |
+| +------------------------------------------------------+ |
+|                                                           |
+| [+ Add Satellite]  [+ Add from Presets]  [Export]        |
+|                                        [Remove Selected] |
++----------------------------------------------------------+
+```
+
+**Legend:**
+- `[O]` = Colored circle showing orbit trail color
+- `#` = Priority number
+- Rows are draggable for reordering
+
+### 5.5 Tab: Schedule
+
+```
++----------------------------------------------------------+
+| UPDATE SCHEDULE                                           |
+| +------------------------------------------------------+ |
+| | Update Frequency: [Every 15 minutes  v]              | |
+| |                                                       | |
+| | More frequent updates ensure accurate day/night      | |
+| | cycles and satellite positions.                      | |
+| +------------------------------------------------------+ |
+|                                                           |
+| TASK STATUS                                               |
+| +------------------------------------------------------+ |
+| | Status: [*] Active                                   | |
+| | Next Run: Jan 22, 2026 at 3:45 PM                    | |
+| | Triggers: 3 (Interval, Logon, Wake)                  | |
+| |                                                       | |
+| | [Disable Task]  [Run Now]  [View in Task Scheduler]  | |
+| +------------------------------------------------------+ |
+|                                                           |
+| STARTUP OPTIONS                                           |
+| +------------------------------------------------------+ |
+| | [x] Run at Windows startup                           | |
+| | [x] Run when resuming from sleep                     | |
+| | [x] Minimize to system tray on close                 | |
+| +------------------------------------------------------+ |
++----------------------------------------------------------+
+```
+
+### 5.6 Tab: Advanced
+
+```
++----------------------------------------------------------+
+| DATA MANAGEMENT                                           |
+| +------------------------------------------------------+ |
+| | TLE Cache: %APPDATA%\WorldMapWallpaper\tle_cache\    | |
+| | Cache Status: 3 satellites cached, oldest 2h ago     | |
+| |                                                       | |
+| | [Refresh All TLE Data]  [Clear Cache]                | |
+| +------------------------------------------------------+ |
+|                                                           |
+| WALLPAPER OUTPUT                                          |
+| +------------------------------------------------------+ |
+| | Location: %USERPROFILE%\Pictures\                    | |
+| | Current: WorldMap01.jpg (2.4 MB)                     | |
+| |                                                       | |
+| | [Open Folder]  [Change Location...]                  | |
+| +------------------------------------------------------+ |
+|                                                           |
+| LOGGING                                                   |
+| +------------------------------------------------------+ |
+| | Log Level: [Info  v]  (Debug, Info, Warning, Error)  | |
+| | Log File: ...\WorldMapWallpaper\log\                 | |
+| |                                                       | |
+| | [View Log File]  [Clear Log]                         | |
+| +------------------------------------------------------+ |
+|                                                           |
+| ABOUT                                                     |
+| +------------------------------------------------------+ |
+| | WorldMapWallpaper v1.5.26.0122                       | |
+| | Copyright (c) 2023-2026                              | |
+| |                                                       | |
+| | [GitHub Repository]  [Report Issue]                  | |
+| +------------------------------------------------------+ |
++----------------------------------------------------------+
+```
+
+### 5.7 Dialog: Edit Satellite
+
+```
++--------------------------------------------+
+|  Edit Satellite                       [X]  |
++--------------------------------------------+
+|                                            |
+|  Name:     [International Space Station  ] |
+|  NORAD ID: [25544                        ] |
+|                                            |
+|  DISPLAY OPTIONS                           |
+|  +----------------------------------------+|
+|  | [x] Enabled                            ||
+|  | [x] Show orbital path                  ||
+|  +----------------------------------------+|
+|                                            |
+|  APPEARANCE                                |
+|  +----------------------------------------+|
+|  | Priority: [  1  ] (lower = higher)     ||
+|  |                                        ||
+|  | Orbit Color:                           ||
+|  | [#FF6B35] [Pick...] [Suggest]          ||
+|  | [====== Color preview bar ======]      ||
+|  +----------------------------------------+|
+|                                            |
+|  ICON                                      |
+|  +----------------------------------------+|
+|  | (*) Use default icon for category      ||
+|  |     Category: [Space Station  v]       ||
+|  |                                        ||
+|  | ( ) Use custom icon:                   ||
+|  |     [                      ] [Browse]  ||
+|  |                                        ||
+|  | Preview: [32x32 icon preview]          ||
+|  +----------------------------------------+|
+|                                            |
+|             [Cancel]  [Save]               |
++--------------------------------------------+
+```
+
+### 5.8 Dialog: Add from Presets
+
+```
++----------------------------------------------------+
+|  Add Satellites from Presets                  [X]  |
++----------------------------------------------------+
+|                                                     |
+|  Filter: [All Categories  v]  Search: [________]   |
+|                                                     |
+|  +-----------------------------------------------+ |
+|  | [ ] | Name                      | ID    | Cat | |
+|  |-----|---------------------------|-------|-----| |
+|  | [-] | International Space St... | 25544 | Stn | |
+|  |     | (Already added)                         | |
+|  |-----|---------------------------|-------|-----| |
+|  | [x] | Hubble Space Telescope    | 20580 | Sci | |
+|  |-----|---------------------------|-------|-----| |
+|  | [x] | Tiangong Space Station    | 48274 | Stn | |
+|  |-----|---------------------------|-------|-----| |
+|  | [ ] | Landsat 9                 | 49260 | EO  | |
+|  |-----|---------------------------|-------|-----| |
+|  | [ ] | GOES-18                   | 51850 | Wx  | |
+|  |-----|---------------------------|-------|-----| |
+|  | [ ] | Terra                     | 25994 | Sci | |
+|  +-----------------------------------------------+ |
+|                                                     |
+|  Selected: 2 satellites                            |
+|                                                     |
+|                [Cancel]  [Add Selected]            |
++----------------------------------------------------+
+```
+
+### 5.9 Dialog: Import/Export
+
+**Export Dialog:**
+```
++--------------------------------------------+
+|  Export Satellite Configuration       [X]  |
++--------------------------------------------+
+|                                            |
+|  Export includes:                          |
+|  - All configured satellites (3)           |
+|  - Custom colors and priorities            |
+|  - Visibility settings                     |
+|                                            |
+|  Note: Custom icon files are NOT exported. |
+|  Only icon paths are saved in the config.  |
+|                                            |
+|  Save to: [                    ] [Browse]  |
+|                                            |
+|           [Cancel]  [Export]               |
++--------------------------------------------+
+```
+
+**Import Dialog:**
+```
++--------------------------------------------+
+|  Import Satellite Configuration       [X]  |
++--------------------------------------------+
+|                                            |
+|  File: satellites_backup.json              |
+|                                            |
+|  Found 5 satellites in configuration:      |
+|  +--------------------------------------+  |
+|  | [x] ISS (25544) - will update        |  |
+|  | [x] Hubble (20580) - will update     |  |
+|  | [x] Tiangong (48274) - NEW           |  |
+|  | [x] Landsat 9 (49260) - NEW          |  |
+|  | [x] GOES-18 (51850) - NEW            |  |
+|  +--------------------------------------+  |
+|                                            |
+|  Import mode:                              |
+|  (*) Merge with existing (update + add)   |
+|  ( ) Replace all (delete existing first)  |
+|                                            |
+|           [Cancel]  [Import]               |
++--------------------------------------------+
+```
+
+### 5.10 Live Preview Implementation
+
+The live preview thumbnail should:
+
+1. **Size:** 320x180 pixels (16:9 aspect ratio)
+2. **Update Frequency:** Every 5 seconds while Settings window is open
+3. **Generation:** Use a lightweight render path (skip some effects if needed)
+4. **Interactivity:** Click to see full-size preview in a popup
+
+```csharp
+private async Task UpdatePreviewAsync()
+{
+    // Generate preview on background thread
+    var previewBitmap = await Task.Run(() =>
+    {
+        // Use current settings to generate small preview
+        return GeneratePreview(320, 180, Settings.Current);
+    });
+
+    // Update UI on main thread
+    _previewPictureBox.Image?.Dispose();
+    _previewPictureBox.Image = previewBitmap;
+    _lastUpdateLabel.Text = $"Last updated: just now";
+}
+
+private System.Windows.Forms.Timer _previewTimer;
+
+private void StartPreviewUpdates()
+{
+    _previewTimer = new System.Windows.Forms.Timer { Interval = 5000 };
+    _previewTimer.Tick += async (s, e) => await UpdatePreviewAsync();
+    _previewTimer.Start();
+
+    // Initial update
+    _ = UpdatePreviewAsync();
+}
+```
+
+---
+
+## 6. Implementation Plan
+
+### 6.1 Phase 1: Core Infrastructure
+
+**New Files:**
+```
+Shared/
+  Models/
+    SatelliteConfig.cs       # Satellite configuration model
+    SatellitePreset.cs       # Preset satellite definition
+  Services/
+    SatelliteConfigManager.cs  # Load/save satellite configurations
+    BatchTleService.cs         # Batch TLE fetching with timeout
+    LagrangePointDetector.cs   # Detect L-point satellites
+```
+
+**Modified Files:**
+```
+Shared/
+  Settings.cs                # Add satellite-related settings
+  TleDataService.cs          # Support batch fetching, timeouts
+```
+
+### 6.2 Phase 2: Multi-Satellite Tracking
+
+**New Files:**
+```
+ImagePainter/
+  MultiSatelliteTracker.cs   # Track and render multiple satellites
+  SatelliteRenderer.cs       # Render single satellite (extracted from ISSTracker)
+  Resources/
+    Icons/
+      satellite-default.png
+      satellite-station.png
+      satellite-telescope.png
+      satellite-weather.png
+      satellite-earth-obs.png
+      satellite-science.png
+      satellite-gps.png
+```
+
+**Modified Files:**
+```
+ImagePainter/
+  Program.cs                 # Use MultiSatelliteTracker
+  ISSTracker.cs              # Refactor, possibly deprecate
+```
+
+### 6.3 Phase 3: Settings UI Redesign
+
+**New Files:**
+```
+Settings/
+  Controls/
+    SatelliteListControl.cs    # Draggable satellite list
+    LivePreviewControl.cs      # Live thumbnail preview
+  Dialogs/
+    SatelliteEditDialog.cs     # Add/Edit satellite
+    PresetSelectorDialog.cs    # Select from presets
+    ImportExportDialog.cs      # Import/Export config
+    LagrangeWarningDialog.cs   # L-point warning
+  TabPages/
+    DisplayTabPage.cs          # Display settings tab
+    SatellitesTabPage.cs       # Satellite management tab
+    ScheduleTabPage.cs         # Schedule settings tab
+    AdvancedTabPage.cs         # Advanced settings tab
+```
+
+**Modified Files:**
+```
+Settings/
+  SettingsForm.cs              # Refactor to tabbed interface
+  SettingsForm.Designer.cs     # Update layout
+```
+
+### 6.4 Phase 4: Polish and Testing
+
+- Icon set finalization
+- Color palette refinement
+- Performance testing with 15 satellites
+- Import/Export testing
+- Lagrange point detection testing
+- UI accessibility review
+
+---
+
+## 7. Design Decisions Summary
+
+| Question | Decision |
+|----------|----------|
+| Lagrange point satellites? | Warn user, allow with disclaimer |
+| API request limits? | 50 satellites max, 5s timeout, batch preferred, async fallback |
+| Satellite groups (Starlink)? | No - cannot be reliably tracked over time |
+| Orbit colors? | Auto-suggest from palette, user can override |
+| Live preview? | Yes - 320x180 thumbnail, updates every 5 seconds |
+| Dark/Light mode? | Already implemented - leverage existing |
+| Import/Export? | Yes - JSON configuration files |
+
+---
+
+## 8. Future Enhancements
+
+After initial implementation, consider:
+
+- **Ground Station Tracking:** Show satellite passes over user's location
+- **Visibility Predictions:** Calculate when satellites are visible
+- **Multi-Monitor Support:** Different wallpapers per monitor
+- **Satellite Telemetry Overlay:** Show altitude, speed, etc.
+- **Notification System:** Alert when specific satellite is overhead
+- **Cloud Sync:** Sync satellite configurations across devices
+
+---
+
+## Appendix A: Earth-Orbiting Satellites by NORAD ID
+
+| NORAD ID | Name | Type | Orbit |
+|----------|------|------|-------|
+| 25544 | ISS (ZARYA) | Space Station | LEO |
+| 48274 | CSS (TIANHE) | Space Station | LEO |
+| 20580 | HST (Hubble) | Telescope | LEO |
+| 43013 | NOAA 20 | Weather | LEO |
+| 51850 | GOES 18 | Weather | GEO |
+| 49260 | LANDSAT 9 | Earth Obs | LEO |
+| 41019 | GPS IIF-12 | Navigation | MEO |
+| 28654 | NOAA 18 | Weather | LEO |
+| 33591 | NOAA 19 | Weather | LEO |
+| 27424 | AQUA | Earth Science | LEO |
+| 25994 | TERRA | Earth Science | LEO |
+| 40697 | SENTINEL-2A | Earth Obs | LEO |
+| 39084 | LANDSAT 8 | Earth Obs | LEO |
+
+---
+
+## Appendix B: Known Lagrange Point Satellites
+
+These satellites should trigger a warning if user attempts to add them:
+
+| NORAD ID | Name | L-Point | Distance from Earth |
+|----------|------|---------|---------------------|
+| 50463 | James Webb Space Telescope | L2 | ~1.5 million km |
+| 43435 | DSCOVR | L1 | ~1.5 million km |
+| 39479 | Gaia | L2 | ~1.5 million km |
+| 28928 | SOHO | L1 | ~1.5 million km |
+| 52195 | Euclid | L2 | ~1.5 million km |
+
+---
+
+## Appendix C: CelesTrak API Reference
+
+**Single Satellite TLE:**
+```
+GET https://celestrak.org/NORAD/elements/gp.php?CATNR=25544&FORMAT=TLE
+```
+
+**Multiple Satellites (comma-separated):**
+```
+GET https://celestrak.org/NORAD/elements/gp.php?CATNR=25544,20580,48274&FORMAT=TLE
+```
+
+**By Group:**
+```
+GET https://celestrak.org/NORAD/elements/gp.php?GROUP=stations&FORMAT=TLE
+```
+
+**Response Format (TLE):**
+```
+ISS (ZARYA)
+1 25544U 98067A   24001.50000000  .00016717  00000-0  10270-3 0  9025
+2 25544  51.6400 208.9163 0006703 276.5736  83.4654 15.49999999999999
+```
+
+---
+
+*Document Version: 2.0*
+*Last Updated: January 2026*


### PR DESCRIPTION
feat(satellites): add multi-satellite tracking & UI

● Add support for tracking and displaying multiple satellites
● Implement SatelliteConfig, SatellitePreset, and config manager
● Add BatchTleService for efficient TLE fetching and caching
● Detect and warn about Lagrange point satellites
● Support custom icons and orbit trail colors per satellite
● Redesign settings UI with tabbed interface and satellite management
● Store satellite config in JSON; support import/export
● Add dialogs for adding/editing satellites with validation
● Update theming and settings for new features
● Bump version to 2.0.0; preserve legacy ISS-only mode for fallback
● Add detailed feature proposal documentation